### PR TITLE
(I25-35)userDropDown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY package*.json ./
 RUN npm ci
 RUN npm install --platform=linuxmusl --arch=x64 sharp
 COPY . .
-RUN echo 'import type { NextConfig } from "next"; const nextConfig: NextConfig = {typescript: {ignoreBuildErrors: true,},eslint: {ignoreDuringBuilds: true,},output: "standalone",images: { domains: ["lh3.googleusercontent.com"] },}};export default nextConfig;' > ./next.config.ts
+RUN echo 'import type { NextConfig } from "next"; const nextConfig: NextConfig = {typescript: {ignoreBuildErrors: true,},eslint: {ignoreDuringBuilds: true,},output: "standalone",images: { domains: ["lh3.googleusercontent.com"] },};export default nextConfig;' > ./next.config.ts
 RUN npm run build
 
 # Production Stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY package*.json ./
 RUN npm ci
 RUN npm install --platform=linuxmusl --arch=x64 sharp
 COPY . .
-RUN echo 'import type { NextConfig } from "next"; const nextConfig: NextConfig = {typescript: {ignoreBuildErrors: true,},eslint: {ignoreDuringBuilds: true,},output: "standalone",};export default nextConfig;' > ./next.config.ts
+RUN echo 'import type { NextConfig } from "next"; const nextConfig: NextConfig = {typescript: {ignoreBuildErrors: true,},eslint: {ignoreDuringBuilds: true,},output: "standalone",images: { domains: ["lh3.googleusercontent.com"] },}};export default nextConfig;' > ./next.config.ts
 RUN npm run build
 
 # Production Stage

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: { domains: ['lh3.googleusercontent.com'] },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@tailwindcss/line-clamp": "^0.4.4",
         "date-fns": "^4.1.0",
         "google-one-tap": "^1.0.6",
-        "next": "^15.1.4",
+        "next": "^15.2.0",
         "next-mdx-remote": "^5.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -353,9 +353,10 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.1.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.1.4.tgz",
-      "integrity": "sha512-2fZ5YZjedi5AGaeoaC0B20zGntEHRhi2SdWcu61i48BllODcAmmtj8n7YarSPt4DaTsJaBFdxQAVEVzgmx2Zpw=="
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.0.tgz",
+      "integrity": "sha512-eMgJu1RBXxxqqnuRJQh5RozhskoNUDHBFybvi+Z+yK9qzKeG7dadhv/Vp1YooSZmCnegf7JxWuapV77necLZNA==",
+      "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "15.0.2",
@@ -368,12 +369,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.4.tgz",
-      "integrity": "sha512-wBEMBs+np+R5ozN1F8Y8d/Dycns2COhRnkxRc+rvnbXke5uZBHkUGFgWxfTXn5rx7OLijuUhyfB+gC/ap58dDw==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.0.tgz",
+      "integrity": "sha512-rlp22GZwNJjFCyL7h5wz9vtpBVuCt3ZYjFWpEPBGzG712/uL1bbSkS675rVAUCRZ4hjoTJ26Q7IKhr5DfJrHDA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -383,12 +385,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.4.tgz",
-      "integrity": "sha512-7sgf5rM7Z81V9w48F02Zz6DgEJulavC0jadab4ZsJ+K2sxMNK0/BtF8J8J3CxnsJN3DGcIdC260wEKssKTukUw==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.0.tgz",
+      "integrity": "sha512-DiU85EqSHogCz80+sgsx90/ecygfCSGl5P3b4XDRVZpgujBm5lp4ts7YaHru7eVTyZMjHInzKr+w0/7+qDrvMA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -398,12 +401,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.4.tgz",
-      "integrity": "sha512-JaZlIMNaJenfd55kjaLWMfok+vWBlcRxqnRoZrhFQrhM1uAehP3R0+Aoe+bZOogqlZvAz53nY/k3ZyuKDtT2zQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.0.tgz",
+      "integrity": "sha512-VnpoMaGukiNWVxeqKHwi8MN47yKGyki5q+7ql/7p/3ifuU2341i/gDwGK1rivk0pVYbdv5D8z63uu9yMw0QhpQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -413,12 +417,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.4.tgz",
-      "integrity": "sha512-7EBBjNoyTO2ipMDgCiORpwwOf5tIueFntKjcN3NK+GAQD7OzFJe84p7a2eQUeWdpzZvhVXuAtIen8QcH71ZCOQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.0.tgz",
+      "integrity": "sha512-ka97/ssYE5nPH4Qs+8bd8RlYeNeUVBhcnsNUmFM6VWEob4jfN9FTr0NBhXVi1XEJpj3cMfgSRW+LdE3SUZbPrw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -428,12 +433,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.1.4.tgz",
-      "integrity": "sha512-9TGEgOycqZFuADyFqwmK/9g6S0FYZ3tphR4ebcmCwhL8Y12FW8pIBKJvSwV+UBjMkokstGNH+9F8F031JZKpHw==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.0.tgz",
+      "integrity": "sha512-zY1JduE4B3q0k2ZCE+DAF/1efjTXUsKP+VXRtrt/rJCTgDlUyyryx7aOgYXNc1d8gobys/Lof9P9ze8IyRDn7Q==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -443,12 +449,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.4.tgz",
-      "integrity": "sha512-0578bLRVDJOh+LdIoKvgNDz77+Bd85c5JrFgnlbI1SM3WmEQvsjxTA8ATu9Z9FCiIS/AliVAW2DV/BDwpXbtiQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.0.tgz",
+      "integrity": "sha512-QqvLZpurBD46RhaVaVBepkVQzh8xtlUN00RlG4Iq1sBheNugamUNPuZEH1r9X1YGQo1KqAe1iiShF0acva3jHQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -458,12 +465,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.4.tgz",
-      "integrity": "sha512-JgFCiV4libQavwII+kncMCl30st0JVxpPOtzWcAI2jtum4HjYaclobKhj+JsRu5tFqMtA5CJIa0MvYyuu9xjjQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.0.tgz",
+      "integrity": "sha512-ODZ0r9WMyylTHAN6pLtvUtQlGXBL9voljv6ujSlcsjOxhtXPI1Ag6AhZK0SE8hEpR1374WZZ5w33ChpJd5fsjw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -473,12 +481,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.1.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.4.tgz",
-      "integrity": "sha512-xxsJy9wzq7FR5SqPCUqdgSXiNXrMuidgckBa8nH9HtjjxsilgcN6VgXF6tZ3uEWuVEadotQJI8/9EQ6guTC4Yw==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.0.tgz",
+      "integrity": "sha512-8+4Z3Z7xa13NdUuUAcpVNA6o76lNPniBd9Xbo02bwXQXnZgFvEopwY2at5+z7yHl47X9qbZpvwatZ2BRo3EdZw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -5003,11 +5012,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.1.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.1.4.tgz",
-      "integrity": "sha512-mTaq9dwaSuwwOrcu3ebjDYObekkxRnXpuVL21zotM8qE2W0HBOdVIdg2Li9QjMEZrj73LN96LcWcz62V19FjAg==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.2.0.tgz",
+      "integrity": "sha512-VaiM7sZYX8KIAHBrRGSFytKknkrexNfGb8GlG6e93JqueCspuGte8i4ybn8z4ww1x3f2uzY4YpTaBEW4/hvsoQ==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "15.1.4",
+        "@next/env": "15.2.0",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -5022,14 +5032,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.1.4",
-        "@next/swc-darwin-x64": "15.1.4",
-        "@next/swc-linux-arm64-gnu": "15.1.4",
-        "@next/swc-linux-arm64-musl": "15.1.4",
-        "@next/swc-linux-x64-gnu": "15.1.4",
-        "@next/swc-linux-x64-musl": "15.1.4",
-        "@next/swc-win32-arm64-msvc": "15.1.4",
-        "@next/swc-win32-x64-msvc": "15.1.4",
+        "@next/swc-darwin-arm64": "15.2.0",
+        "@next/swc-darwin-x64": "15.2.0",
+        "@next/swc-linux-arm64-gnu": "15.2.0",
+        "@next/swc-linux-arm64-musl": "15.2.0",
+        "@next/swc-linux-x64-gnu": "15.2.0",
+        "@next/swc-linux-x64-musl": "15.2.0",
+        "@next/swc-win32-arm64-msvc": "15.2.0",
+        "@next/swc-win32-x64-msvc": "15.2.0",
         "sharp": "^0.33.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@tailwindcss/line-clamp": "^0.4.4",
     "date-fns": "^4.1.0",
     "google-one-tap": "^1.0.6",
-    "next": "^15.1.4",
+    "next": "^15.2.0",
     "next-mdx-remote": "^5.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/auth/logout/page.tsx
+++ b/src/app/auth/logout/page.tsx
@@ -1,12 +1,19 @@
-import { createClient } from '@/utils/supabase/server';
-import { redirect } from 'next/navigation';
+'use client';
 
-const Logout = async () => {
-  const supabase = await createClient();
+import OverlayBg from '@/app/components/layout/overlay/OverlayBg';
+import { useEffect } from 'react';
 
-  supabase.auth.signOut().then(() => {
-    console.log('Signed out');
-  });
-  return redirect('/');
+const LogoutPage = () => {
+  useEffect(() => {
+    window.location.href = '/';
+  }, []);
+  return (
+    <OverlayBg>
+      <div className="bg-white py-5 px-8 rounded-lg">
+        <h1 className="text-xl font-bold">로그아웃 중...</h1>
+      </div>
+    </OverlayBg>
+  );
 };
-export default Logout;
+
+export default LogoutPage;

--- a/src/app/auth/logout/template.tsx
+++ b/src/app/auth/logout/template.tsx
@@ -1,0 +1,11 @@
+import { createClient } from '@/utils/supabase/server';
+
+const LogoutTemplate = async ({ children }: { children: React.ReactNode }) => {
+  const supabase = await createClient();
+
+  supabase.auth.signOut().then(() => {
+    console.log('Signed out');
+  });
+  return children;
+};
+export default LogoutTemplate;

--- a/src/app/components/Dropdown.tsx
+++ b/src/app/components/Dropdown.tsx
@@ -1,0 +1,31 @@
+import type { Dropdown } from '../models/dropdown';
+import OverlayBg from './layout/overlay/OverlayBg';
+import DropdownItem from './DropdownItem';
+
+interface DropdownProps extends Dropdown {
+  OverayBgColor?: string;
+}
+
+const Dropdown = (dropdown: DropdownProps) => {
+  return (
+    <>
+      {dropdown.setOverlayBg && (
+        <OverlayBg
+          backgroundColor={dropdown.OverayBgColor || '#00000000'}
+          onBackgroundClick={() => {
+            if (dropdown.setOverlayBg) dropdown.setOverlayBg(false);
+          }}
+        />
+      )}
+      <div className="absolute top-8 right-0 bg-white rounded-lg p-2 shadow-md min-w-[14rem] border-gray-500 border-[0.5px] z-50">
+        {dropdown.items.map((item, index) => (
+          <DropdownItem key={index} icon={item.icon} onClick={item.onClick}>
+            {item.children}
+          </DropdownItem>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default Dropdown;

--- a/src/app/components/DropdownItem.tsx
+++ b/src/app/components/DropdownItem.tsx
@@ -1,0 +1,31 @@
+import { MouseEventHandler } from 'react';
+
+const DropdownItem = ({
+  children,
+  icon,
+  onClick,
+}: {
+  children?: React.ReactNode;
+  icon: string;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className="stroke-[0.5px] stroke-gray-500 flex gap-2 items-center p-2 rounded-lg hover:bg-gray-100 cursor-pointer w-full"
+    >
+      <span
+        className="material-symbols-outlined"
+        style={{
+          fontVariationSettings: "'FILL' 1, 'wght' 300, 'GRAD' 0, 'opsz' 20",
+          fontSize: '1.5rem',
+        }}
+      >
+        {icon}
+      </span>
+      {children}
+    </button>
+  );
+};
+
+export default DropdownItem;

--- a/src/app/components/auth/GoogleOneTab.tsx
+++ b/src/app/components/auth/GoogleOneTab.tsx
@@ -4,7 +4,6 @@ import Script from 'next/script';
 import { createClient } from '@/utils/supabase/client';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
-import { User } from '@supabase/supabase-js';
 
 // google 전역 객체에 대한 타입 정의
 declare global {
@@ -25,11 +24,7 @@ interface CredentialResponse {
   select_by: string;
 }
 
-const OneTapComponent = ({
-  setUser,
-}: {
-  setUser: React.Dispatch<React.SetStateAction<User | null>>;
-}) => {
+const OneTapComponent = () => {
   const supabase = createClient();
 
   const router = useRouter();
@@ -81,7 +76,6 @@ const OneTapComponent = ({
             if (error) throw error;
             console.log('Session data: ', data);
             console.log('Successfully logged in with Google One Tap');
-            setUser(data.user);
           } catch (error) {
             console.error('Error logging in with Google One Tap', error);
           }

--- a/src/app/components/layout/header/AccountComponent.tsx
+++ b/src/app/components/layout/header/AccountComponent.tsx
@@ -1,61 +1,76 @@
 'use client';
 
-import { createClient } from '@/utils/supabase/client';
-import { useState, useEffect } from 'react';
-import { User } from '@supabase/supabase-js';
-import OneTapComponent from '../../auth/GoogleOneTab';
 import MakeProfileOverlay from '../overlay/MakeProfile';
+import { createClient } from '@/utils/supabase/client';
+import OneTapComponent from '../../auth/GoogleOneTab';
+import { User } from '@supabase/supabase-js';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Dropdown from '@components/Dropdown';
+import Image from 'next/image';
 
-const openLoginPopup = () => {
-  // login popup
-  const popup = window.open(
-    `${window.location.origin}/auth/login`,
-    '_blank',
-    'popup,scrollbars=yes,resizable=yes,width=500,height=800',
-  );
-
-  popup?.focus();
-
-  // close popup
-  window.addEventListener('message', (event) => {
-    if (event.origin !== window.location.origin) return;
-
-    if (event.data === 'success') {
-      popup?.close();
-      window.location.reload();
-    }
-  });
-};
-const AccountComponent = () => {
-  const supabase = createClient();
-  const [user, setUser] = useState<User | null>(null);
-
-  useEffect(() => {
-    supabase.auth.getUser().then((res) => {
-      setUser(res.data.user);
-    });
-  }, []);
-
-  return user ? UserProfile(user) : signInButton(setUser);
-};
-
-export default AccountComponent;
-function UserProfile(user: User) {
+const UserProfile = ({ user }: { user: User }) => {
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
+  const router = useRouter();
   return (
-    <>
-      <img
-        src={user.user_metadata.avatar_url}
-        alt="Profile Image"
-        className="h-7 rounded-full"
-      />
+    <div className="relative">
+      <button
+        className="block"
+        onClick={() => setDropdownOpen(!isDropdownOpen)}
+      >
+        <Image
+          src={user.user_metadata.avatar_url}
+          alt="Profile Image"
+          width={21}
+          height={21}
+          className="rounded-full object-cover"
+        />
+      </button>
+      {isDropdownOpen && (
+        <Dropdown
+          items={[
+            {
+              icon: 'shield_person',
+              children: '계정설정',
+              onClick: () => {
+                router.push('/mypage');
+              },
+            },
+            {
+              icon: 'move_item',
+              children: '로그아웃',
+              onClick: () => {
+                router.push('/auth/logout');
+              },
+            },
+          ]}
+          setOverlayBg={setDropdownOpen}
+        />
+      )}
       <MakeProfileOverlay />
-    </>
+    </div>
   );
-}
+};
 
-function signInButton(
-  setUser: React.Dispatch<React.SetStateAction<User | null>>,
-) {
+const SignInButton = () => {
+  const openLoginPopup = () => {
+    const popup = window.open(
+      `${window.location.origin}/auth/login`,
+      '_blank',
+      'popup,scrollbars=yes,resizable=yes,width=500,height=800',
+    );
+
+    popup?.focus();
+
+    window.addEventListener('message', (event) => {
+      if (event.origin !== window.location.origin) return;
+
+      if (event.data === 'success') {
+        popup?.close();
+      }
+    });
+  };
+
   return (
     <>
       <button
@@ -64,7 +79,32 @@ function signInButton(
       >
         sign in
       </button>
-      <OneTapComponent setUser={setUser} />
+      <OneTapComponent />
     </>
   );
-}
+};
+
+const AccountComponent = () => {
+  const supabase = createClient();
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then((res) => {
+      setUser(res.data.user);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      subscription?.unsubscribe();
+    };
+  }, []);
+
+  return user ? <UserProfile user={user} /> : <SignInButton />;
+};
+
+export default AccountComponent;

--- a/src/app/components/layout/overlay/MakeProfile.tsx
+++ b/src/app/components/layout/overlay/MakeProfile.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import getProfileBySession from '@/services/profile/getProfileBySession';
+import OverlayBg from './OverlayBg';
 
 const MakeProfileOverlay = () => {
   const pathname = usePathname();
@@ -25,30 +26,37 @@ const MakeProfileOverlay = () => {
 
   if (pathname === '/community/new-profile') return null; // 이미 새 프로필 만들기 페이지에 있는 경우 제외
 
-  return !isHide ? (
-    <div className="absolute w-[100vw] h-[100vh] top-0 left-0 flex justify-center items-center bg-[#00000085] text-titleColor">
-      <main className="bg-white rounded-3xl p-6">
-        <h2 className="text-2xl font-bold">프로필 생성하기</h2>
-        <p>아직 프로필이 없어요. 프로필을 생성하고 모든 기능을 사용해보세요.</p>
-        <Link
-          className="bg-black text-white flex flex-col justify-center items-center rounded-xl p-6 mt-4 aspect-[5/3] text-xl gap-2"
-          href={`/community/new-profile`}
-        >
-          <span
-            className="material-symbols-outlined"
-            style={{
-              fontVariationSettings:
-                "'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 48",
-              fontSize: '2rem',
-            }}
+  return (
+    !isHide && (
+      <OverlayBg
+        backgroundColor="#00000085"
+        onBackgroundClick={() => setHide(true)}
+      >
+        <main className="bg-white rounded-3xl p-6">
+          <h2 className="text-2xl font-bold">프로필 생성하기</h2>
+          <p>
+            아직 프로필이 없어요. 프로필을 생성하고 모든 기능을 사용해보세요.
+          </p>
+          <Link
+            className="bg-black text-white flex flex-col justify-center items-center rounded-xl p-6 mt-4 aspect-[5/3] text-xl gap-2"
+            href={`/community/new-profile`}
           >
-            account_circle
-          </span>
-          프로필 생성
-        </Link>
-      </main>
-    </div>
-  ) : null;
+            <span
+              className="material-symbols-outlined"
+              style={{
+                fontVariationSettings:
+                  "'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 48",
+                fontSize: '2rem',
+              }}
+            >
+              account_circle
+            </span>
+            프로필 생성
+          </Link>
+        </main>
+      </OverlayBg>
+    )
+  );
 };
 
 export default MakeProfileOverlay;

--- a/src/app/components/layout/overlay/OverlayBg.tsx
+++ b/src/app/components/layout/overlay/OverlayBg.tsx
@@ -1,0 +1,27 @@
+const OverlayBg = ({
+  children,
+  backgroundColor = '#00000085',
+  onBackgroundClick,
+}: {
+  children?: React.ReactNode;
+  backgroundColor?: string;
+  onBackgroundClick?: () => void;
+}) => {
+  const handleClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget && onBackgroundClick) {
+      onBackgroundClick();
+    }
+  };
+
+  return (
+    <div
+      className="fixed w-[100vw] h-[100vh] top-0 left-0 flex justify-center items-center z-50"
+      style={{ backgroundColor }}
+      onClick={handleClick}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default OverlayBg;

--- a/src/app/models/dropdown.d.ts
+++ b/src/app/models/dropdown.d.ts
@@ -1,0 +1,10 @@
+export interface DropdownItem {
+  icon: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+export interface Dropdown {
+  setOverlayBg?: React.Dispatch<React.SetStateAction<boolean>>;
+  items: Array<DropdownItem>;
+}


### PR DESCRIPTION
## 💡 개요
헤더에 사용자 계정 아이콘을 클릭했을 때 나타나는 드롭다운 매뉴를 작성함.
## 📃 작업내용
- 드롭다운 매뉴 표출
  - 드롭다운 매뉴가 표시된 상태에서는 드롭다운 박스 이외의 영역에 투명 배경이 표시되며, 투명 배경을 클릭했을 때, 드롭다운 박스가 숨겨집니다.
- 로그아웃시 Layout Persistence 로 인해 기존 프로필 표시가 로그인 버튼으로 재렌더링 되지 않는 문제가 있어 해결함.
  - 로그아웃 로직은 Server Side 에서 기존과 같이 처리하지만, 리다이렉트를 Next 의 리다이렉트가 아닌 `window.location.href` 를 사용해 Client Side 에서 처리하였음.
## 🔀 변경사항
- Dropdown 표준을 새로 만들었습니다.
  `/src/app/models/dropdown.d.ts` 와 `/src/app/components/Dropdown` 을 참고하세요.
- 헤더에 표시되는 프로필 이미지를 img 태그에서 Image 태그로 교체하고, `next.config.ts` 에서 google 프로필 이미지를 로드할 수 있도록 허용 도메인을 작성했습니다.
## 📸 스크린샷
![image](https://github.com/user-attachments/assets/1e92a047-8935-4978-9cf2-63ec05921689)
<img width="1256" alt="로그아웃 페이지에 접근했을 때, 로그아웃 로직을 처리한 후, 리다이렉트를 대기하는 화면" src="https://github.com/user-attachments/assets/9d35379a-cf40-4402-8698-2770b5be5966" />
<label>로그아웃 페이지에 접근했을 때, 로그아웃 로직을 처리한 후, 리다이렉트를 대기하는 화면</label>

