### PR TITLE
[I25-70] jira issue code regex update

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^5"
   },
   "jira-prepare-commit-msg": {
-    "jiraTicketPattern": "([A-Z0-9]+-\\d+)",
+    "jiraTicketPattern": "I25-\\d+",
     "allowEmptyCommitMessage": false,
     "ignoredBranchesPattern": "^(master|main|dev|develop|development|release)$",
     "ignoreBranchesMissingTickets": false


### PR DESCRIPTION
## 💡 개요
터미널에서 브랜치 이름 중 괄호를 사용함으로써 발생하는 불편을 해결하기 위해 jira 이슈 코드를 자동으로 커밋 메시지에 추가할 때 사용하는 Regex 를 업데이트 하였습니다. 
## 📃 작업내용
`package.json` 업데이트
## 🔀 변경사항
앞으로 브랜치 이름에 괄호를 사용하여 지라 이슈 번호를 표기하지 않으셔도 됩니다.

### Example
`(I25-30)feat/asdf` -> `feat/I25-30-asdf`
