### PR TITLE
(i25 166) 404 not found PR

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Link from 'next/link';
+import { Title, Body } from '@/app/components/system/text';
+
+export default function NotFound() {
+  return (
+    <div className="flex-center-all h-screen">
+      <Title className="mb-4">404 - 페이지를 찾을 수 없습니다</Title>
+      <Body className="mb-8">요청하신 페이지가 존재하지 않습니다</Body>
+      <Link
+        href="/"
+        className="px-6 py-3 bg-blue-primary text-white rounded-full"
+      >
+        홈으로 돌아가기
+      </Link>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -4,9 +4,9 @@ import { Title, Body } from '@/app/components/system/text';
 
 export default function NotFound() {
   return (
-    <div className="flex-center-all h-screen">
-      <Title className="mb-4">404 - 페이지를 찾을 수 없습니다</Title>
-      <Body className="mb-8">요청하신 페이지가 존재하지 않습니다</Body>
+    <div className="flex-center-all h-screen gap-4">
+      <Title>404 - 페이지를 찾을 수 없습니다</Title>
+      <Body className="mb-4">요청하신 페이지가 존재하지 않습니다</Body>
       <Link
         href="/"
         className="px-6 py-3 bg-blue-primary text-white rounded-full"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,7 +68,8 @@ const config: Config = {
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-        },'.flex-x-center': {
+        },
+        '.flex-x-center': {
           display: 'flex',
           justifyContent: 'space-between',
         },
@@ -76,11 +77,17 @@ const config: Config = {
           display: 'flex',
           alignItems: 'center',
         },
-        '.inline-flex-center' : {
+        '.inline-flex-center': {
           display: 'inline-flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-        }
+        },
+        '.flex-center-all': {
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+        },
       });
     },
   ],


### PR DESCRIPTION
## 💡 개요
404페이지에 접근하면 헤더부터 시작해 모든 글씨가 흰색으로 변하는 현상 수정
## 📃 작업내용
not-found.tsx파일 추가 후 404페이지 들어설 시 보여줄 글자와 홈으로 돌아가는 button 추가.
flex-col과 flex-center을 같이 써야할 상황 때문에 tailwind.config.ts에 둘다 적용하는 코드 추가
## 🔀 변경사항

## 📸 스크린샷
<img width="3024" height="1859" alt="image" src="https://github.com/user-attachments/assets/e295fe4b-1676-4583-9107-044c40529ee2" />
