### PR TITLE
(i25 165) feat/responsive header footer

### DIFF
--- a/src/app/components/layout/Footer.tsx
+++ b/src/app/components/layout/Footer.tsx
@@ -2,42 +2,44 @@ import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { Body, Heading } from '../system/text';
+import Navigator from './Navigator';
 
 export default function Footer() {
   return (
-    <footer className="p-white-space-margin bg-light-gray-footer-bg flex-center flex-row text-gray-footer h-[8rem]">
-      <div className="flex flex-col">
-        <Link href="" className="text-xl mb-4">
-          <Heading>
-            부산소프트웨어마이스터고 프로젝트의장
-          </Heading>
-        </Link>
-          <Link href="https://maps.app.goo.gl/4BsSV2Kr4PXQ6JYD8">
-        <Body>
-            부산광역시 강서구 가락대로 1393 부산소프트웨어마이스터고등학교
-        </Body>
+    <>
+      <Navigator />
+      <footer className="p-white-space-margin py-10 bg-light-gray-footer-bg flex-center gap-[1.5rem] text-gray-footer responsive-footer">
+        <div className="flex flex-col mobile:mr-auto">
+          <Link href="" className="text-xl mb-4">
+            <Heading>
+              부산소프트웨어마이스터고 프로젝트의장
+            </Heading>
           </Link>
-          <Link href="">
-          <Body>
-            산학문의 (051) 000-0000
+            <Link href="https://maps.app.goo.gl/4BsSV2Kr4PXQ6JYD8">
+          <Body className=''>
+              부산광역시 강서구 가락대로 1393 부산소프트웨어마이스터고등학교
           </Body>
-          </Link>
-      </div>
-      <div>
-        <div className="flex gap-4 mb-2">
-          <Link href=""><Body>Term of Use</Body></Link>
-          <Link href=""><Body>Privacy Policy</Body></Link>
+            <Body>
+              산학문의 (051) 000-0000
+            </Body>
+            </Link>
         </div>
-        <div className="flex gap-2 justify-end">
-          <Image
-            src="/icon/insert.svg"
-            alt="insert-logo"
-            width={21}
-            height={20}
-          />
-          <span><Body>Powered by INSERT</Body></span>
+        <div className='mobile:ml-auto'>
+          <div className="flex gap-4 mb-2">
+            <Link href=""><Body>Term of Use</Body></Link>
+            <Link href=""><Body>Privacy Policy</Body></Link>
+          </div>
+          <div className="flex gap-2 justify-end">
+            <Image
+              src="/icon/insert.svg"
+              alt="insert-logo"
+              width={21}
+              height={20}
+            />
+            <span><Body>Powered by INSERT</Body></span>
+          </div>
         </div>
-      </div>
-    </footer>
+      </footer>
+    </>
   );
 }

--- a/src/app/components/layout/Footer.tsx
+++ b/src/app/components/layout/Footer.tsx
@@ -15,14 +15,14 @@ export default function Footer() {
               부산소프트웨어마이스터고 프로젝트의장
             </Heading>
           </Link>
-            <Link href="https://maps.app.goo.gl/4BsSV2Kr4PXQ6JYD8">
-          <Body className=''>
-              부산광역시 강서구 가락대로 1393 부산소프트웨어마이스터고등학교
-          </Body>
+          <Link href="https://maps.app.goo.gl/4BsSV2Kr4PXQ6JYD8">
+            <Body className=''>
+                부산광역시 강서구 가락대로 1393 부산소프트웨어마이스터고등학교
+            </Body>
             <Body>
               산학문의 (051) 000-0000
             </Body>
-            </Link>
+          </Link>
         </div>
         <div className='mobile:ml-auto'>
           <div className="flex gap-4 mb-2">

--- a/src/app/components/layout/Header.tsx
+++ b/src/app/components/layout/Header.tsx
@@ -3,16 +3,17 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { Label } from '../system/text';
 
+export const navigation = [
+  { label: '프로젝트', href: '/projects/all' },
+  { label: '동아리', href: '/clubs/all' },
+  { label: '포트폴리오', href: '/portfolio/all' },
+  { label: '대회', href: '/majors/all' },
+];
+
 const Header = () => {
-  const navigation = [
-    { label: '프로젝트', href: '/projects/all' },
-    { label: '동아리', href: '/clubs/all' },
-    { label: '포트폴리오', href: '/portfolio/all' },
-    { label: '대회', href: '/majors/all' },
-  ];
 
   return (
-    <header className="flex-center p-white-space-margin h-14 border-b border-[light-gray-outline]">
+    <header className="p-white-space-margin flex-center h-14 border-b border-[light-gray-outline] responsive-header">
       <div className="flex-row items-center">
         <Image
           src="/icon/logo.svg"
@@ -21,11 +22,11 @@ const Header = () => {
           height="21"
           className="pr-2"
         />
-        <Link href="/" className="text-xl text-titleColor">
+        <Link href="/" className="text-xl text-titleColor whitespace-nowrap">
           <b>부산소프트웨어마이스터고</b> 프로젝트의장
         </Link>
       </div>
-      <nav className="flex-row gap-4">
+      <nav className="flex-row gap-4 mobile:hidden">
         {navigation.map((item) => (
           <Link key={item.label} href={item.href}>
             <Label>{item.label}</Label>

--- a/src/app/components/layout/Navigator.tsx
+++ b/src/app/components/layout/Navigator.tsx
@@ -1,0 +1,38 @@
+
+'use client';
+import Link from 'next/link';
+import { IconStarFilled } from '@tabler/icons-react';
+import { navigation } from './Header';
+import { usePathname } from 'next/navigation';
+
+const Navigator = () => {
+  const pathName = usePathname();
+
+  const extendedNavigation = [
+    ...navigation,
+    { label: '홈', href: '/'}
+  ]
+
+  return (
+    <nav className='hidden responsive-navigator'>
+      {extendedNavigation.map((({label, href}) => {
+        const isActiveColor = pathName === href ? '#007AFF' : '#999'
+
+        return (
+          <Link
+            key={label}
+            href={href}
+            className='flex-col flex-center'
+          >
+            <IconStarFilled
+              color={`${isActiveColor}`}
+            />
+            <div style={{ color: isActiveColor }}>{label}</div>
+          </Link>
+        )
+      }))}
+    </nav>
+  )
+}
+
+export default Navigator;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 // src/app/layout.tsx
 import Footer from './components/layout/Footer';
 import './globals.css';
+import './responsive.css'
 import Header from '@components/layout/Header';
 // import Footer from '@components/layout/Footer';
 

--- a/src/app/responsive.css
+++ b/src/app/responsive.css
@@ -5,4 +5,17 @@
     align-items: center;
     padding: 0 0;
   }
+
+  .responsive-navigator {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.75rem 1.75rem;
+    padding-bottom: 2.25rem;
+  }
+
+  .responsive-footer {
+    display: flex;
+    flex-direction: column;
+    padding: 2.5rem 2.5rem;
+  }
 }

--- a/src/app/responsive.css
+++ b/src/app/responsive.css
@@ -16,6 +16,6 @@
   .responsive-footer {
     display: flex;
     flex-direction: column;
-    padding: 2.5rem 2.5rem;
+    padding: 2.5rem;
   }
 }

--- a/src/app/responsive.css
+++ b/src/app/responsive.css
@@ -1,0 +1,8 @@
+@media (max-width: 900px) {
+  .responsive-header {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0 0;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,11 @@ const config: Config = {
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
+    screens: {
+      mobile: {
+        max: '900px'
+      }
+    },
     extend: {
       lineClamp: {
         7: '7',


### PR DESCRIPTION
## 💡 개요
Header와 Footer가 크기에 따라 반응형으로 작동하게 수정하였습니다.

## 📃 작업내용
1. Header 반응형 적용
2. Footer 반응형 적용
3. Header 에서 사라진 nav를 Footer 위에 위치시킴

## 🔀 변경사항
1. tailwind.config.ts 에 mobile 크기(900px) 지정 
2. media-query용 responsive.css 추가 _(앞으로 반응형 디자인은 여기에 작성)_

## 📸 스크린샷
**(해당 스크린샷은 아이폰 15pro 기준입니다.)**
### Header 컴포넌트
| Desktop | Mobile |
|---|---|
| <img width="1500" height="220" alt="스크린샷 2025-09-20 오후 10 33 46" src="https://github.com/user-attachments/assets/ed9cdc2a-cb7b-4ffa-9fb2-6c000326a080" /> | <img width="456" height="500" alt="스크린샷 2025-09-20 오후 10 33 22" src="https://github.com/user-attachments/assets/215e9b05-9ef5-43f3-94a8-26140ee16e67" /> |


### Footer 컴포넌트 & Navigator 컴포넌트
| Desktop | Mobile |
|---|---|
| <img width="1500" height="151" alt="스크린샷 2025-09-20 오후 10 35 02" src="https://github.com/user-attachments/assets/e002f00f-8155-4b5d-b684-e6701e07ebb6" /> | <img width="458" height="500" alt="스크린샷 2025-09-20 오후 10 34 41" src="https://github.com/user-attachments/assets/bafc2a52-fe3c-4843-8206-02b786e71f7e" /> |
