### PR TITLE
[I25-214] feat: 검색 입력 필드에 아이콘 추가 및 사이드바 최소 너비 수정

### DIFF
--- a/src/app/(box-layout)/portfolio/SearchTab.tsx
+++ b/src/app/(box-layout)/portfolio/SearchTab.tsx
@@ -98,8 +98,9 @@ export default function SearchTab({
   return (
     <div className="pt-8 flex mobile:flex-col flex-row gap-4 min-h-dvh w-full">
       {/* 검색 및 필터 사이드바 */}
-      <aside className="flex-col gap-3 min-w-80">
+      <aside className="flex-col gap-3 min-w-[25rem]">
         <Inputs
+          icon='search'
           onChange={(e) => setSearchTerm(e.target.value)}
           placeholder="Search"
         />

--- a/src/app/components/collect/CollectClient.tsx
+++ b/src/app/components/collect/CollectClient.tsx
@@ -95,7 +95,7 @@ export default function CollectClient({
 
   return (
     <div className="flex flex-col items-start gap-6 flex-1 shrink-0">
-      <div className="w-full max-w-[25rem]">
+      <div className="w-full max-w-[25rem] mobile:max-w-full">
         <Inputs
           type="text"
           icon="search"


### PR DESCRIPTION
## 💡 개요
포트폴리오 검색 페이지에 검색 아이콘 추가 및 최소 너비를 프로젝트 검색과 같은 크기로 동기화했습니다

## 📃 작업내용

## 🔀 변경사항

## 📸 스크린샷
<img width="1093" height="828" alt="image" src="https://github.com/user-attachments/assets/6106c8c1-fb28-4a14-aa27-b3ff8b38664b" />
