### PR TITLE
(i25 227) fix/card style

### DIFF
--- a/src/app/components/card/project/MetaInfo.tsx
+++ b/src/app/components/card/project/MetaInfo.tsx
@@ -12,9 +12,9 @@ interface MetaInfoProps {
 
 const MetaInfo = ({ description, authors }: MetaInfoProps) => {
   return (
-    <figcaption className="flex-x-center">
-      <Label className="text-gray-base">{description}</Label>
-      <div className="flex-y-center gap-1">
+    <figcaption className="flex-x-center gap-4">
+      <Label className="text-gray-base truncate">{description}</Label>
+      <div className="flex-y-center gap-1 shrink-0">
         {authors.length === 1 ? (
           // 작성자가 1명인 경우: 프로필 사진 + 이름
           <>

--- a/src/app/components/card/project/ProjectCard.tsx
+++ b/src/app/components/card/project/ProjectCard.tsx
@@ -32,7 +32,7 @@ const Card = ({
 
   return (
     <Link href={href} className="cursor-pointer">
-      <div className="w-full mobile:max-w-full max-w-[26rem] flex-col gap-[0.375rem]">
+      <div className="w-full mobile:max-w-full mobile:min-w-[26rem] max-w-[26rem] flex-col gap-[0.375rem]">
         <figure className="relative h-60 mobile:h-80 aspect-video rounded-[0.25rem] overflow-hidden">
           <Image
             src={projectImage}


### PR DESCRIPTION
## 💡 개요
### Card 컴포넌트가 찌그러지는 문제 해결

## 📃 작업내용
1. Card 컴포넌트가 모바일에서 찌그러지는 문제를 해결했습니다.
2. description 이 길 경우, MetaInfo가 Card 컴포넌트의 크기를 벗어나는 문제를 해결했습니다.

## 🔀 변경사항
1. Card 컴포넌트 mobile:min-w-[26rem] 추가
2. description 에 truncate ,authors div 에 shrink-0 속성 추가

## 📸 스크린샷
| Before | After |
| --- | --- |
| <img width="510" height="703" alt="스크린샷 2025-10-30 오전 1 26 55" src="https://github.com/user-attachments/assets/a2c521e3-e963-4ae9-9c82-3e1006f5b5bc" /> | <img width="400" height="497" alt="스크린샷 2025-10-30 오전 1 27 27" src="https://github.com/user-attachments/assets/244d560c-3358-4833-b926-c74ec0b2623c" /> |
| <img width="536" height="445" alt="스크린샷 2025-10-30 오전 1 27 49" src="https://github.com/user-attachments/assets/249657d7-2f02-4897-b226-281aeea21f01" /> | <img width="259" height="210" alt="스크린샷 2025-10-30 오전 1 28 20" src="https://github.com/user-attachments/assets/98e64cf8-3471-497c-b884-3c71d3a05382" /> |




