### PR TITLE
I25 232 hotfix/명함을 넘기는 손 의 조회 로직 수정 PR

### DIFF
--- a/src/app/(box-layout)/portfolio/types.d.ts
+++ b/src/app/(box-layout)/portfolio/types.d.ts
@@ -49,7 +49,7 @@ export type ProfileWithProjects = MergeDeep<
             >;
           }[])
       | null;
-    student:
+    student?:
       | Pick<Tables<'student'>, 'name' | 'join_at' | 'graduate_at'> & {
           department: Tables<'departments'>;
           student_jobs:

--- a/src/services/server/portfolio/getPaginatedPortfolioData.ts
+++ b/src/services/server/portfolio/getPaginatedPortfolioData.ts
@@ -1,11 +1,14 @@
 import { createClient } from '@/utils/supabase/client';
 import { convertFromDatabaseImageURL } from '@/utils/supabase/imageHostConverter';
-import { PortfolioData, ProfileWithProjects } from '@/app/(box-layout)/portfolio/types';
+import {
+  PortfolioData,
+  ProfileWithProjects,
+} from '@/app/(box-layout)/portfolio/types';
 import { PaginatedPortfolioResponse } from '@/types/pagination';
 
 export async function getPaginatedPortfolioData(
   page: number = 1,
-  limit: number = 5
+  limit: number = 5,
 ): Promise<PaginatedPortfolioResponse> {
   const supabase = await createClient();
   const offset = (page - 1) * limit;
@@ -52,7 +55,7 @@ export async function getPaginatedPortfolioData(
           status
         )
       ),
-      student(
+      profile_owner_fkey1(
         name,
         join_at,
         graduate_at,
@@ -99,7 +102,7 @@ export async function getPaginatedPortfolioData(
     return {
       profile: {
         name: data.profile_name,
-        role: data.student.student_jobs?.map(({ job }) => job.job_name) || [],
+        role: data.student?.student_jobs?.map(({ job }) => job.job_name) || [],
         bio: data.description!,
         status: '구직 중',
         profile_image: convertFromDatabaseImageURL(data.profile_image),

--- a/src/services/server/portfolio/getPersonalPortfolioData.ts
+++ b/src/services/server/portfolio/getPersonalPortfolioData.ts
@@ -1,6 +1,9 @@
 import { createClient } from '@/utils/supabase/client';
 import { convertFromDatabaseImageURL } from '@/utils/supabase/imageHostConverter';
-import { PortfolioData, ProfileWithProjects } from '@/app/(box-layout)/portfolio/types';
+import {
+  PortfolioData,
+  ProfileWithProjects,
+} from '@/app/(box-layout)/portfolio/types';
 
 export async function getPersonalPortfolioData(): Promise<PortfolioData[]> {
   const supabase = await createClient();
@@ -64,7 +67,7 @@ export async function getPersonalPortfolioData(): Promise<PortfolioData[]> {
     return {
       profile: {
         name: data.profile_name,
-        role: data.student.student_jobs?.map(({ job }) => job.job_name) || [],
+        role: data.student?.student_jobs?.map(({ job }) => job.job_name) || [],
         bio: data.description!,
         status: '구직 중',
         profile_image: convertFromDatabaseImageURL(data.profile_image),

--- a/src/utils/hook/useInfinitePortfolio.ts
+++ b/src/utils/hook/useInfinitePortfolio.ts
@@ -8,22 +8,33 @@ export function useInfinitePortfolio() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
 
   const loadMore = useCallback(async () => {
-    if (isLoading) return;
+    if (isLoading || !hasMore) return;
 
     setIsLoading(true);
     try {
-      const response = await fetch(`/api/portfolio/paginated?page=${page}&limit=5`);
+      const response = await fetch(
+        `/api/portfolio/paginated?page=${page}&limit=5`,
+      );
       const result = await response.json();
 
-      if (result.data) {
+      if (result.data && result.data.length > 0) {
         setData((prev) => {
           const existing = new Set(prev.map((item) => item.profile.name));
-          const newData = result.data.filter((item: PortfolioData) => !existing.has(item.profile.name));
+          const newData = result.data.filter(
+            (item: PortfolioData) => !existing.has(item.profile.name),
+          );
           return [...prev, ...newData];
         });
         setPage((prev) => prev + 1);
+
+        if (result.data.length < 5) {
+          setHasMore(false);
+        }
+      } else {
+        setHasMore(false);
       }
     } catch (err) {
       console.error('Failed to load portfolio data', err);
@@ -31,11 +42,11 @@ export function useInfinitePortfolio() {
     } finally {
       setIsLoading(false);
     }
-  }, [isLoading, page]);
+  }, [isLoading, page, hasMore]);
 
   useEffect(() => {
     loadMore();
-  }, [loadMore]);
+  }, []);
 
-  return { data, isLoading, error, loadMore };
+  return { data, isLoading, error, loadMore, hasMore };
 }


### PR DESCRIPTION
## 💡 개요
백엔드 조회가 안되던 오류, 200이 뜬 api 무한 호출 해결

loadMore가 실행되면 page상태가 변경되지만 page가 변경되면 loadMore 함수가 재 생성됨. loadMore이 재생성 되면 useEffect가 재생성되면서 무한 api 요청을 보내던 오류 해결

## 📃 작업내용
bugfix

## 🔀 변경사항

## 📸 스크린샷
<img width="462" height="496" alt="image" src="https://github.com/user-attachments/assets/651445d3-9023-40f2-ac05-f356cca82ffa" />
