### PR TITLE
[I25-236] fix: Material Symbols 아이콘 폰트 적용 오류 수정

### DIFF
--- a/src/app/components/modal/inputs/Checkbox.tsx
+++ b/src/app/components/modal/inputs/Checkbox.tsx
@@ -8,12 +8,13 @@ interface CheckboxProps {
 
 const Checkbox = ({ checked, onChange, label = '체크박스' }: CheckboxProps) => {
   const [state, setState] = useState(false);
+  const isChecked = checked ?? state;
   
   return (
     <label
       className="flex flex-row items-center gap-2 cursor-pointer select-none"
       onClick={() => {
-        const next = !(checked ?? state);
+        const next = !isChecked;
         setState(next);
         onChange?.(next);
       }}
@@ -21,10 +22,13 @@ const Checkbox = ({ checked, onChange, label = '체크박스' }: CheckboxProps) 
       <span 
         className="material-symbols-outlined text-[24px] transition-colors"
         style={{ 
-          fontVariationSettings: `'FILL' ${(checked ?? state) ? 1 : 0}, 'wght' 400, 'GRAD' 0, 'opsz' 24`
+          fontVariationSettings: `'FILL' ${isChecked ? 1 : 0}, 'wght' 400, 'GRAD' 0, 'opsz' 24`,
+          fontFamily: "'Material Symbols Outlined'",
+          fontWeight: 'normal',
+          fontStyle: 'normal',
         }}
       >
-        {(checked ?? state) ? 'check_box' : 'check_box_outline_blank'}
+        {isChecked ? 'check_box' : 'check_box_outline_blank'}
       </span>
       {label}
     </label>


### PR DESCRIPTION
## 💡 개요

- Material Symbols 아이콘 체크박스가 폰트 적용 문제로 인해 정상적으로 렌더링되지 않는 이슈를 해결하기 위한 hotfix입니다.

## 📃 작업내용

- Checkbox 컴포넌트에 `fontFamily`를 `'Material Symbols Outlined'`로 명시적으로 추가
- `fontVariationSettings`와 함께 `fontFamily`, `fontWeight`, `fontStyle` 속성 추가
- 코드 가독성을 위해 `isChecked` 변수 도입, 불필요한 중첩 표현 개선

## 🔀 변경사항

- Checkbox 아이콘 렌더링 방식 개선(폰트 관련 CSS 속성 정상 반영)
- 내부 변수 정리 및 의미 명확화
- 전체적으로 7줄 추가, 3줄 삭제 (`src/app/components/modal/inputs/Checkbox.tsx` 기준)

## 📸 스크린샷
<img width="528" height="1108" alt="image" src="https://github.com/user-attachments/assets/f7ca00d4-958d-4035-9d42-b38128a36038" />

