### PR TITLE
[I25-236] fix: Checkbox 컴포넌트에 Material Symbols 아이콘 적용

### DIFF
--- a/src/app/components/modal/inputs/Checkbox.tsx
+++ b/src/app/components/modal/inputs/Checkbox.tsx
@@ -20,12 +20,9 @@ const Checkbox = ({ checked, onChange, label = '체크박스' }: CheckboxProps) 
       }}
     >
       <span 
-        className="material-symbols-outlined text-[24px] transition-colors"
+        className="icon-checkbox font-material-symbols transition-colors"
         style={{ 
-          fontVariationSettings: `'FILL' ${isChecked ? 1 : 0}, 'wght' 400, 'GRAD' 0, 'opsz' 24`,
-          fontFamily: "'Material Symbols Outlined'",
-          fontWeight: 'normal',
-          fontStyle: 'normal',
+          fontVariationSettings: `'FILL' ${isChecked ? 1 : 0}, 'wght' 400, 'GRAD' 0, 'opsz' 24`
         }}
       >
         {isChecked ? 'check_box' : 'check_box_outline_blank'}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -45,6 +45,7 @@ const config: Config = {
       },
       fontFamily: {
         threat: ['Threat', 'sans-serif'],
+        'material-symbols': ['Material Symbols Outlined', 'sans-serif'],
       },
       maxWidth: {
         outer: '92.5rem',
@@ -105,6 +106,21 @@ const config: Config = {
           display: 'inline-flex',
           justifyContent: 'space-between',
           alignItems: 'center',
+        },
+        '.icon-checkbox': {
+          fontFamily: "'Material Symbols Outlined'",
+          fontWeight: 'normal',
+          fontStyle: 'normal',
+          fontSize: '24px',
+          lineHeight: 1,
+          letterSpacing: 'normal',
+          textTransform: 'none',
+          display: 'inline-block',
+          whiteSpace: 'nowrap',
+          wordWrap: 'normal',
+          direction: 'ltr',
+          WebkitFontFeatureSettings: "'liga'",
+          WebkitFontSmoothing: 'antialiased',
         },
       });
     },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -108,7 +108,6 @@ const config: Config = {
           alignItems: 'center',
         },
         '.icon-checkbox': {
-          fontFamily: "'Material Symbols Outlined'",
           fontWeight: 'normal',
           fontStyle: 'normal',
           fontSize: '24px',


### PR DESCRIPTION
## 💡 개요
- Checkbox 컴포넌트에서 Material Symbols 아이콘 폰트가 정상적으로 적용되지 않는 버그를 수정하는 핫픽스입니다.

## 📃 작업내용
- `tailwind.config.ts`에 `'Material Symbols Outlined'` 폰트 패밀리를 추가했습니다.
- 체크박스 전용 `.icon-checkbox` 유틸리티 클래스를 Tailwind custom CSS로 생성했습니다.
- Checkbox 컴포넌트에서 아이콘 렌더링에 필요한 Tailwind/Material Symbols 클래스를 적용하여 폰트 이슈를 해결했습니다.

## 🔀 변경사항
- `tailwind.config.ts`:  
  - fontFamily에 `'material-symbols'` 추가  
  - `.icon-checkbox` 커스텀 유틸리티 클래스 신규 정의
- `src/app/components/modal/inputs/Checkbox.tsx`:  
  - 아이콘 className 및 폰트 스타일 적용 방식 변경