### PR TITLE
(i25 244) feat/프로필 이미지가 꽉 채워지지 않는 버그

### DIFF
--- a/src/app/(box-layout)/team/TeamSidebar.tsx
+++ b/src/app/(box-layout)/team/TeamSidebar.tsx
@@ -60,7 +60,7 @@ const TeamSidebar = async ({ teamDetail, projectCount }: TeamSidebarProps) => {
               key={member.profile.profile_id}
               src={member.profile.profile_image}
               size={{ width: 32, height: 32 }}
-              variant="circle"
+              shape="circle"
             />
           ))}
         </div>

--- a/src/app/(box-layout)/team/TeamSidebar.tsx
+++ b/src/app/(box-layout)/team/TeamSidebar.tsx
@@ -1,12 +1,11 @@
-import Image from 'next/image';
 import ProfileItem from '@/app/components/contents/ProfileItem';
 import TeamLabel from '@/app/components/contents/TeamLabel';
 import { Body, Label, TitleEN } from '@/app/components/system/text';
 import { TeamData } from './types';
-import { convertFromDatabaseImageURL } from '@/utils/supabase/imageHostConverter';
 import { getFoundedYear } from '@/utils/date';
 import getMyAccount from '@/services/server/auth/getMyAccount';
 import TeamProfileEditButton from '@/app/components/card/portfolio/TeamProfileEditButton';
+import ProfileImage from '@/app/components/card/portfolio/components/ProfileImage';
 
 interface TeamSidebarProps {
   teamDetail: TeamData;
@@ -57,13 +56,11 @@ const TeamSidebar = async ({ teamDetail, projectCount }: TeamSidebarProps) => {
         <Label className="mb-1.5">팀원</Label>
         <div className="flex flex-wrap gap-2">
           {teamDetail?.team_member.map((member) => (
-            <Image
+            <ProfileImage
               key={member.profile.profile_id}
-              src={convertFromDatabaseImageURL(member.profile.profile_image)}
-              alt="팀원 프로필 사진"
-              width={32}
-              height={32}
-              className="rounded-full"
+              src={member.profile.profile_image}
+              size={{ width: 32, height: 32 }}
+              variant="circle"
             />
           ))}
         </div>

--- a/src/app/components/card/portfolio/ProfileIcon.tsx
+++ b/src/app/components/card/portfolio/ProfileIcon.tsx
@@ -1,14 +1,12 @@
-import Image from 'next/image';
-import { convertFromDatabaseImageURL } from '@/utils/supabase/imageHostConverter';
+import ProfileImage from './components/ProfileImage';
 
 const ProfileIcon = ({ image }: { image: string }) => {
   return (
-    <Image
-      width={(120 / 16) * 14}
-      height={(120 / 16) * 14}
-      alt="프로필 사진"
-      src={convertFromDatabaseImageURL(image)}
-      className="rounded-sm absolute -top-20"
+    <ProfileImage
+      src={image}
+      size={{ width: (120 / 16) * 14, height: (120 / 16) * 14 }}
+      variant="rounded"
+      className="absolute -top-20"
     />
   );
 };

--- a/src/app/components/card/portfolio/ProfileIcon.tsx
+++ b/src/app/components/card/portfolio/ProfileIcon.tsx
@@ -5,7 +5,7 @@ const ProfileIcon = ({ image }: { image: string }) => {
     <ProfileImage
       src={image}
       size={{ width: (120 / 16) * 14, height: (120 / 16) * 14 }}
-      variant="rounded"
+      shape="rounded"
       className="absolute -top-20"
     />
   );

--- a/src/app/components/card/portfolio/components/ProfileImage.tsx
+++ b/src/app/components/card/portfolio/components/ProfileImage.tsx
@@ -60,13 +60,18 @@ function ProfileImage({
   const variantClassName = getVariantClassName(variant);
 
   return (
-    <Image
-      src={imageSrc}
-      alt={imageAlt}
-      width={width}
-      height={height}
-      className={`object-cover ${variantClassName} w-full h-full ${className ?? ''}`}
-    />
+    <div 
+      className={`shrink-0 ${className ?? ''}`}
+      style={{ width: `${width}px`, height: `${height}px` }}
+    >
+      <Image
+        src={imageSrc}
+        alt={imageAlt}
+        width={width}
+        height={height}
+        className={`object-cover ${variantClassName} w-full h-full`}
+      />
+    </div>
   );
 }
 

--- a/src/app/components/card/portfolio/components/ProfileImage.tsx
+++ b/src/app/components/card/portfolio/components/ProfileImage.tsx
@@ -13,7 +13,7 @@ const sizeMap: Record<PresetSize, { width: number; height: number }> = {
   large: { width: 75, height: 75 },
 };
 
-type Variant = 'circle' | 'square' | 'rounded';
+type Shape = 'circle' | 'square' | 'rounded';
 
 const DEFAULT_FALLBACK_PROFILE =
   process.env.NEXT_PUBLIC_PROJECT_FALLBACK_PROFILE ?? '/default-avatar.svg';
@@ -23,12 +23,12 @@ interface ProfileImageProps {
   /** 프로필 이름 (alt 텍스트 생성에 사용) */
   name?: string;
   size: Size;
-  variant?: Variant;
+  shape?: Shape;
   className?: string;
 }
 
-const getVariantClassName = (variant: Variant): string => {
-  switch (variant) {
+const getShapeClassName = (shape: Shape): string => {
+  switch (shape) {
     case 'circle':
       return 'rounded-full';
     case 'square':
@@ -44,7 +44,7 @@ function ProfileImage({
   src,
   name,
   size,
-  variant = 'circle',
+  shape = 'circle',
   className,
 }: ProfileImageProps) {
   const { width, height } = typeof size === 'string' ? sizeMap[size] : size;
@@ -57,7 +57,7 @@ function ProfileImage({
   
   const imageAlt = name ? `${name} 프로필` : '프로필 사진';
 
-  const variantClassName = getVariantClassName(variant);
+  const shapeClassName = getShapeClassName(shape);
 
   return (
     <div 
@@ -69,12 +69,12 @@ function ProfileImage({
         alt={imageAlt}
         width={width}
         height={height}
-        className={`object-cover ${variantClassName} w-full h-full`}
+        className={`object-cover ${shapeClassName} w-full h-full`}
       />
     </div>
   );
 }
 
 export default ProfileImage;
-export type { ProfileImageProps, Size, Variant };
+export type { ProfileImageProps, Size, Shape };
 export { DEFAULT_FALLBACK_PROFILE };

--- a/src/app/components/card/portfolio/components/ProfileImage.tsx
+++ b/src/app/components/card/portfolio/components/ProfileImage.tsx
@@ -1,38 +1,75 @@
 import React from 'react';
 import Image from 'next/image';
+import { convertFromDatabaseImageURL } from '@/utils/supabase/imageHostConverter';
 
-type Size = 'tiny' | 'small' | 'medium' | 'large';
-const sizeMap: Record<Size, { width: number; height: number }> = {
+type PresetSize = 'tiny' | 'small' | 'medium' | 'large';
+type CustomSize = { width: number; height: number };
+type Size = PresetSize | CustomSize;
+
+const sizeMap: Record<PresetSize, { width: number; height: number }> = {
   tiny: { width: 15, height: 15 },
   small: { width: 45, height: 45 },
   medium: { width: 54, height: 54 },
   large: { width: 75, height: 75 },
 };
+
+type Variant = 'circle' | 'square' | 'rounded';
+
+const DEFAULT_FALLBACK_PROFILE =
+  process.env.NEXT_PUBLIC_PROJECT_FALLBACK_PROFILE ?? '/card/dummy-profile.png';
+
 interface ProfileImageProps {
-  src: string;
+  src?: string | null;
+  /** 프로필 이름 (alt 텍스트 생성에 사용) */
   name?: string;
   size: Size;
+  variant?: Variant;
   className?: string;
-  style?: React.CSSProperties;
 }
+
+const getVariantClassName = (variant: Variant): string => {
+  switch (variant) {
+    case 'circle':
+      return 'rounded-full';
+    case 'square':
+      return 'rounded-none';
+    case 'rounded':
+      return 'rounded-sm';
+    default:
+      return 'rounded-full';
+  }
+};
 
 function ProfileImage({
   src,
   name,
   size,
+  variant = 'circle',
   className,
-  style,
 }: ProfileImageProps) {
+  const { width, height } = typeof size === 'string' ? sizeMap[size] : size;
+  
+  const resolvedSrc = src?.trim() || DEFAULT_FALLBACK_PROFILE;
+
+  const imageSrc = resolvedSrc.includes('{{supabaseHost}}')
+    ? convertFromDatabaseImageURL(resolvedSrc)
+    : resolvedSrc;
+  
+  const imageAlt = name ? `${name} 프로필` : '프로필 사진';
+
+  const variantClassName = getVariantClassName(variant);
+
   return (
-    <div className={className ?? 'min-w-fit'} style={style}>
-      <Image
-        src={src}
-        alt={`${name} 프로필`}
-        {...sizeMap[size]}
-        className="object-cover rounded-full"
-      />
-    </div>
+    <Image
+      src={imageSrc}
+      alt={imageAlt}
+      width={width}
+      height={height}
+      className={`object-cover ${variantClassName} w-full h-full ${className ?? ''}`}
+    />
   );
 }
 
 export default ProfileImage;
+export type { ProfileImageProps, Size, Variant };
+export { DEFAULT_FALLBACK_PROFILE };

--- a/src/app/components/card/portfolio/components/ProfileImage.tsx
+++ b/src/app/components/card/portfolio/components/ProfileImage.tsx
@@ -16,7 +16,7 @@ const sizeMap: Record<PresetSize, { width: number; height: number }> = {
 type Variant = 'circle' | 'square' | 'rounded';
 
 const DEFAULT_FALLBACK_PROFILE =
-  process.env.NEXT_PUBLIC_PROJECT_FALLBACK_PROFILE ?? '/card/dummy-profile.png';
+  process.env.NEXT_PUBLIC_PROJECT_FALLBACK_PROFILE ?? '/default-avatar.svg';
 
 interface ProfileImageProps {
   src?: string | null;

--- a/src/app/components/card/project/MetaInfo.tsx
+++ b/src/app/components/card/project/MetaInfo.tsx
@@ -34,7 +34,7 @@ const MetaInfo = ({ description, authors }: MetaInfoProps) => {
                 src={author.profileImage}
                 name={author.name}
                 size="tiny"
-                style={{ zIndex: authors.length - index }}
+                className={`z-[${authors.length - index}]`}
               />
             ))}
           </div>

--- a/src/app/components/card/root/BusinessCard.tsx
+++ b/src/app/components/card/root/BusinessCard.tsx
@@ -58,7 +58,6 @@ const ProfileHeader = ({ card }: { card: BusinessCardData }) => {
           src={card.profileImage}
           name={card.name}
           size={{ width: 27, height: 27 }}
-          className="shrink-0"
         />
         <div className="flex flex-col grow items-start leading-[1.25] text-[#24292f]">
           <p className="font-bold text-[12px] tracking-[-0.8px] w-full">

--- a/src/app/components/card/root/BusinessCard.tsx
+++ b/src/app/components/card/root/BusinessCard.tsx
@@ -57,9 +57,8 @@ const ProfileHeader = ({ card }: { card: BusinessCardData }) => {
         <ProfileImage
           src={card.profileImage}
           name={card.name}
-          size="small"
+          size={{ width: 27, height: 27 }}
           className="shrink-0"
-          style={{ width: '27px', height: '27px' }}
         />
         <div className="flex flex-col grow items-start leading-[1.25] text-[#24292f]">
           <p className="font-bold text-[12px] tracking-[-0.8px] w-full">

--- a/src/app/components/project/components/project-sidebar/ProjectTeamSection.tsx
+++ b/src/app/components/project/components/project-sidebar/ProjectTeamSection.tsx
@@ -15,7 +15,7 @@ const TeamMemberItem = ({ member }: TeamMemberItemProps) => {
           src={member.profileImage}
           name={member.name}
           size={{ width: 40, height: 40 }}
-          variant="circle"
+          shape="circle"
         />
       </Link>
     <div className="flex-col">

--- a/src/app/components/project/components/project-sidebar/ProjectTeamSection.tsx
+++ b/src/app/components/project/components/project-sidebar/ProjectTeamSection.tsx
@@ -16,7 +16,6 @@ const TeamMemberItem = ({ member }: TeamMemberItemProps) => {
           name={member.name}
           size={{ width: 40, height: 40 }}
           variant="circle"
-          className="relative h-10 w-10 overflow-hidden"
         />
       </Link>
     <div className="flex-col">

--- a/src/app/components/project/components/project-sidebar/ProjectTeamSection.tsx
+++ b/src/app/components/project/components/project-sidebar/ProjectTeamSection.tsx
@@ -1,32 +1,23 @@
-import Image from 'next/image';
 import { Label, Label2 } from '@/app/components/system/text';
-import { convertFromDatabaseImageURL } from '@/utils/supabase/imageHostConverter';
 import type { ProjectDetailViewModel } from '../types';
-import { FALLBACK_PROFILE } from './styles';
 import Link from 'next/link';
+import ProfileImage from '@/app/components/card/portfolio/components/ProfileImage';
 
 interface TeamMemberItemProps {
   member: ProjectDetailViewModel['team'][number];
 }
 
 const TeamMemberItem = ({ member }: TeamMemberItemProps) => {
-  const profileImageUrl = member.profileImage 
-    ? (member.profileImage.includes('{{supabaseHost}}') 
-        ? convertFromDatabaseImageURL(member.profileImage) 
-        : member.profileImage)
-    : FALLBACK_PROFILE;
-
   return (
     <article className="flex-row items-center gap-[0.375rem]">
       <Link href={`/portfolio/${member.name}`} className="cursor-pointer">
-        <div className="relative h-10 w-10 overflow-hidden rounded-full">
-          <Image
-            src={profileImageUrl}
-            alt={member.name}
-            fill
-            className="object-cover"
-          />
-        </div>
+        <ProfileImage
+          src={member.profileImage}
+          name={member.name}
+          size={{ width: 40, height: 40 }}
+          variant="circle"
+          className="relative h-10 w-10 overflow-hidden"
+        />
       </Link>
     <div className="flex-col">
       <Link


### PR DESCRIPTION
## 💡 개요

프로필 이미지가 컨테이너를 꽉 채우지 못하고 여백이 생기는 버그를 수정했습니다. 이를 위해 재사용 가능한 `ProfileImage` 컴포넌트를 새로 생성하고, 이미지가 지정된 크기에 맞게 꽉 채워지도록 `object-cover` 스타일과 부모 컨테이너를 추가했습니다.

## 📃 작업내용

프로필 이미지 표시 로직을 통합하고 일관된 스타일링을 적용하기 위해 `ProfileImage` 컴포넌트를 신규 생성했습니다. 이 컴포넌트는 크기와 형태를 props로 받아 다양한 상황에서 재사용할 수 있도록 설계되었습니다.

### 핵심 변경사항

1. **ProfileImage 컴포넌트 신규 생성**
   - 프리셋 크기(`tiny`, `small`, `medium`, `large`) 및 커스텀 크기 지원
   - 형태 옵션(`circle`, `square`, `rounded`) 지원
   - Supabase 이미지 URL 변환 로직 포함

2. **이미지 꽉 채우기 구현**
   - 부모 `div` 컨테이너에 고정 크기(`width`, `height`) 설정
   - Next.js `Image` 컴포넌트에 `object-cover` 클래스 적용
   - `w-full h-full` 클래스를 통해 이미지가 컨테이너를 완전히 채우도록 설정

3. **사용처 통합**
   - `PortfolioCard` 컴포넌트에서 `ProfileImage` 사용
   - `ProfileIcon` 컴포넌트에서 `ProfileImage` 사용
   - 일관된 프로필 이미지 표시 보장

## 🔀 변경사항

- **기본 fallback 이미지 경로 변경**: 환경변수 `NEXT_PUBLIC_PROJECT_FALLBACK_PROFILE`이 설정되지 않은 경우 기본값을 `/default-avatar.svg`로 변경했습니다.
- **중복 스타일 제거**: 기존에 여러 곳에 분산되어 있던 프로필 이미지 스타일링 로직을 `ProfileImage` 컴포넌트로 통합하여 중복을 제거했습니다.



[I25-244]: https://obtuse-t.atlassian.net/browse/I25-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ