### PR TITLE
[I25-251] feat : 사이드바의 기술스택 컴포넌트를 모달의 기술스택 컴포넌트로 대치시키기

### DIFF
--- a/src/app/(box-layout)/portfolio/types.d.ts
+++ b/src/app/(box-layout)/portfolio/types.d.ts
@@ -9,7 +9,7 @@ export interface ItemProps {
 
 export interface PortfolioDetailProps {
   mode: ItemProps['mode'] | 'skill';
-  datas: Array<Omit<ItemProps, 'mode'> | Omit<TagProps, 'mode'>>;
+  datas: Array<Omit<ItemProps, 'mode'> | (Omit<TagProps, 'mode'> & { skillId?: number })>;
 }
 
 import { Tables } from '@/utils/supabase/database.types';

--- a/src/app/components/card/portfolio/components/PortfolioDetail.tsx
+++ b/src/app/components/card/portfolio/components/PortfolioDetail.tsx
@@ -1,6 +1,6 @@
 import ProfileItem from '@/app/components/contents/ProfileItem';
-import SkillTag from '@/app/components/contents/SkillTag';
 import { Label } from '@/app/components/system/text';
+import SkillTagProvider from '@/app/components/modal/inputs/SkillTagProvider';
 
 import {
   PortfolioDetailProps,
@@ -25,11 +25,13 @@ const PortfolioDetail = ({ details }: PortfolioDetailDataProps) => {
         <div key={mode}>
           <Label>{modeTextMap[mode]}</Label>
           {mode === 'skill' ? (
-            <div className="flex flex-wrap gap-2">
-              {datas.map(({ value }) => (
-                <SkillTag key={value} mode="white" value={value} />
-              ))}
-            </div>
+            <SkillTagProvider
+              readOnly
+              white
+              initialTags={datas
+                .map((data) => ('skillId' in data ? data.skillId : undefined))
+                .filter((id): id is number => id !== undefined)}
+            />
           ) : (
             <div className="flex-col">
               {datas.map((data, index) => (

--- a/src/app/components/project/components/project-sidebar/ProjectSummarySection.tsx
+++ b/src/app/components/project/components/project-sidebar/ProjectSummarySection.tsx
@@ -1,5 +1,5 @@
 import { Body, Body2, Label, TitleEN } from '@/app/components/system/text';
-import SkillTag from '@/app/components/contents/SkillTag';
+import SkillTagProvider from '@/app/components/modal/inputs/SkillTagProvider';
 import {
   PLAY_BUTTON_BORDER_STYLE,
   PLAY_BUTTON_BOTTOM_GLOW_STYLE,
@@ -114,23 +114,14 @@ export const ProjectLinkSection = ({ url }: ProjectLinkSectionProps) => (
   </section>
 );
 
-interface ProjectTechnologiesSectionProps {
-  technologies: string[];
-}
 
 export const ProjectTechnologiesSection = ({
   technologies,
-}: ProjectTechnologiesSectionProps) => (
+}: {
+  technologies: number[];
+}) => (
   <section className="flex-col gap-[0.375rem]">
     <Label>기술스택</Label>
-    <div className="flex-row flex-wrap gap-2">
-      {technologies.length > 0 ? (
-        technologies.map((tech) => (
-          <SkillTag key={tech} mode="default" value={tech} />
-        ))
-      ) : (
-        <Label className="text-detail">기술 스택 정보가 없습니다.</Label>
-      )}
-    </div>
+    <SkillTagProvider readOnly initialTags={technologies} />
   </section>
 );

--- a/src/app/components/project/components/types.ts
+++ b/src/app/components/project/components/types.ts
@@ -17,7 +17,7 @@ export type ProjectDetailViewModel = {
   detailDescription: string;
   githubUrl?: string | null;
   iconImage: string;
-  technologies: string[];
+  technologies: number[];
   team: Array<{
     id: string;
     name: string;

--- a/src/app/components/project/services/mapper/project-mapper.ts
+++ b/src/app/components/project/services/mapper/project-mapper.ts
@@ -21,7 +21,7 @@ export const toViewModel = (
     detailDescription,
     githubUrl: project.link,
     iconImage: project.project_logo,
-    technologies: project.skills ?? [],
+    technologies: project.skills?.map(Number).filter((id): id is number => !isNaN(id)) ?? [],
     team: (project.project_contributors ?? []).map((contributor, index) => ({
       id: contributor.profile_id ?? `member-${index}`,
       name: contributor.profile?.profile_name ?? '이름 미정',

--- a/src/services/server/profile/getProfileDetail.ts
+++ b/src/services/server/profile/getProfileDetail.ts
@@ -66,7 +66,8 @@ export const getProfileDetail = async (profileName: string): Promise<PortfolioDe
     {
       mode: 'skill',
       datas: (data?.profile_skills ?? []).map((item) => ({
-        value: item.skills.skill_name
+        value: item.skills.skill_name,
+        skillId: item.skills.skill_id
       }))
     }
   ]


### PR DESCRIPTION
## 💡 개요
팀, 포트폴리오, 프로젝트 페이지의 사이드바에서 사용하던 기술스택 컴포넌트를 모달에서 사용하는 `SkillTagProvider`의 `readOnly` 모드로 통일하여 컴포넌트 재사용성을 높이고 일관된 UI/UX를 제공합니다.

## 📃 작업내용
사이드바의 기술스택 표시를 `SkillTag` 컴포넌트에서 `SkillTagProvider`의 `readOnly` 모드로 변경했습니다.

**주요 변경사항:**
- 포트폴리오 사이드바: `SkillTagProvider`의 `readOnly` 모드 사용 (white prop 적용)
- 프로젝트 사이드바: `SkillTagProvider`의 `readOnly` 모드 사용
- `getProfileDetail`: skill_id를 함께 반환하도록 수정
- 프로젝트 매퍼: 불필요한 skill_name → skill_id 변환 로직 제거

## 🔀 변경사항
- `ProjectTechnologiesSection`을 별도 파일에서 `ProjectSummarySection.tsx`로 통합하여 모듈화 단순화
- 기술스택이 없을 때 "기술 스택 정보가 없습니다" 메시지 제거 (빈 배열일 경우 아무것도 렌더링하지 않음)
- `ProjectDetailViewModel`의 `technologies` 타입을 `string[]`에서 `number[]`로 변경하여 skill_id 기반으로 통일

## 📸 스크린샷
<img width="428" height="156" alt="image" src="https://github.com/user-attachments/assets/16e991e4-450c-43c1-b3e4-2b3c0043cd59" />
