### PR TITLE
I25-243-fix-profile-edit-button

### DIFF
--- a/src/app/(box-layout)/team/TeamSidebar.tsx
+++ b/src/app/(box-layout)/team/TeamSidebar.tsx
@@ -25,10 +25,7 @@ const TeamSidebar = async ({ teamDetail, projectCount }: TeamSidebarProps) => {
           {teamDetail?.description}
         </Body>
         {currentSession?.id == teamDetail?.owner && (
-          <TeamProfileEditButton
-            profileId={teamDetail?.profile_id || ''}
-            profileName={teamDetail?.profile_name}
-          />
+          <TeamProfileEditButton profileId={teamDetail?.profile_id || ''} />
         )}
       </div>
       <hr className="border-light-gray-outline" />

--- a/src/app/components/card/portfolio/PortfolioHome.tsx
+++ b/src/app/components/card/portfolio/PortfolioHome.tsx
@@ -19,12 +19,11 @@ const PortfolioHome = ({
   details,
   projects,
   ownerId,
-  profile_name,
 }: PortfolioHomeProps) => {
   return (
     <>
       <aside className="flex-col gap-6 sticky top-24 self-start w-[21.75rem] mobile:w-full">
-        <ProfileEditButton ownerId={ownerId} profileName={profile_name} />
+        <ProfileEditButton ownerId={ownerId} />
         <PortfolioItems details={details} />
       </aside>
       <section className="flex-col gap-5">

--- a/src/app/components/card/portfolio/ProfileEditButton.tsx
+++ b/src/app/components/card/portfolio/ProfileEditButton.tsx
@@ -23,11 +23,6 @@ export default function ProfileEditButton({
   // 권한 확인: 현재 사용자가 프로필 소유자인지 확인
   const isOwner = currentUser?.id === ownerId;
 
-  // 로그인하지 않았거나 소유자가 아니면 버튼을 렌더링하지 않음
-  if (!currentUser || !isOwner) {
-    return null;
-  }
-
   const handleProfileEdit = useCallback(async () => {
     if (!currentUser?.id || !isOwner) {
       console.error('User not authorized to edit this profile');
@@ -48,6 +43,11 @@ export default function ProfileEditButton({
       />,
     );
   }, [ownerId, currentUser?.id, isOwner, openModal, closeModal]);
+
+  // 로그인하지 않았거나 소유자가 아니면 버튼을 렌더링하지 않음
+  if (!currentUser || !isOwner) {
+    return null;
+  }
 
   return (
     <button

--- a/src/app/components/card/portfolio/ProfileEditButton.tsx
+++ b/src/app/components/card/portfolio/ProfileEditButton.tsx
@@ -33,7 +33,7 @@ export default function ProfileEditButton({ ownerId }: ProfileEditButtonProps) {
         onClose={closeModal}
       />,
     );
-  }, [ownerId, openModal, closeModal]);
+  }, [ownerId, openModal, closeModal, currentUser?.id]);
 
   // 로그인하지 않았거나 소유자가 아니면 버튼을 렌더링하지 않음
   if (!currentUser || !isOwner) {

--- a/src/app/components/card/portfolio/ProfileEditButton.tsx
+++ b/src/app/components/card/portfolio/ProfileEditButton.tsx
@@ -10,13 +10,9 @@ import { checkProfileExistence } from '@/services/client/profile/profileApi';
 
 interface ProfileEditButtonProps {
   ownerId: string;
-  profileName?: string;
 }
 
-export default function ProfileEditButton({
-  ownerId,
-  profileName,
-}: ProfileEditButtonProps) {
+export default function ProfileEditButton({ ownerId }: ProfileEditButtonProps) {
   const currentUser = useCurrentUser();
   const { openModal, closeModal } = useModal();
 
@@ -29,11 +25,6 @@ export default function ProfileEditButton({
   }
 
   const handleProfileEdit = useCallback(async () => {
-    if (!currentUser?.id || !isOwner) {
-      console.error('User not authorized to edit this profile');
-      return;
-    }
-
     // 프로필 존재 여부 확인
     const profileExists = await checkProfileExistence(ownerId);
 
@@ -47,7 +38,7 @@ export default function ProfileEditButton({
         onClose={closeModal}
       />,
     );
-  }, [ownerId, currentUser?.id, isOwner, openModal, closeModal]);
+  }, [ownerId, openModal, closeModal]);
 
   return (
     <button

--- a/src/app/components/card/portfolio/ProfileEditButton.tsx
+++ b/src/app/components/card/portfolio/ProfileEditButton.tsx
@@ -23,6 +23,11 @@ export default function ProfileEditButton({
   // 권한 확인: 현재 사용자가 프로필 소유자인지 확인
   const isOwner = currentUser?.id === ownerId;
 
+  // 로그인하지 않았거나 소유자가 아니면 버튼을 렌더링하지 않음
+  if (!currentUser || !isOwner) {
+    return null;
+  }
+
   const handleProfileEdit = useCallback(async () => {
     if (!currentUser?.id || !isOwner) {
       console.error('User not authorized to edit this profile');
@@ -44,14 +49,10 @@ export default function ProfileEditButton({
     );
   }, [ownerId, currentUser?.id, isOwner, openModal, closeModal]);
 
-  // profileName은 현재 사용하지 않지만, 향후 로깅이나 디버깅에 사용할 수 있음
-  console.log('Editing profile:', profileName);
-
   return (
     <button
       className="rounded-3xl h-10 flex justify-center items-center gap-3 bg-black text-white w-full"
       onClick={handleProfileEdit}
-      disabled={!currentUser || !isOwner}
     >
       <IconPencil size={12}></IconPencil>
       Edit

--- a/src/app/components/card/portfolio/ProfileEditButton.tsx
+++ b/src/app/components/card/portfolio/ProfileEditButton.tsx
@@ -33,7 +33,7 @@ export default function ProfileEditButton({ ownerId }: ProfileEditButtonProps) {
         onClose={closeModal}
       />,
     );
-  }, [ownerId, openModal, closeModal, currentUser?.id]);
+  }, [ownerId, openModal, closeModal]);
 
   // 로그인하지 않았거나 소유자가 아니면 버튼을 렌더링하지 않음
   if (!currentUser || !isOwner) {

--- a/src/app/components/card/portfolio/TeamProfileEditButton.tsx
+++ b/src/app/components/card/portfolio/TeamProfileEditButton.tsx
@@ -19,6 +19,11 @@ export default function TeamProfileEditButton({
   const currentUser = useCurrentUser();
   const { openModal, closeModal } = useModal();
 
+  // 로그인하지 않은 경우 버튼을 렌더링하지 않음
+  if (!currentUser) {
+    return null;
+  }
+
   const handleProfileEdit = useCallback(async () => {
     if (!currentUser?.id) {
       console.error('User not logged in');
@@ -36,14 +41,10 @@ export default function TeamProfileEditButton({
     );
   }, [profileId, currentUser?.id, openModal, closeModal]);
 
-  // profileName은 현재 사용하지 않지만, 향후 로깅이나 디버깅에 사용할 수 있음
-  console.log('Editing team profile:', profileName);
-
   return (
     <button
       className="rounded-3xl h-10 flex justify-center items-center gap-4 bg-black text-white w-full"
       onClick={handleProfileEdit}
-      disabled={!currentUser}
     >
       <IconPencil size={12}></IconPencil>
       Edit

--- a/src/app/components/card/portfolio/TeamProfileEditButton.tsx
+++ b/src/app/components/card/portfolio/TeamProfileEditButton.tsx
@@ -9,12 +9,10 @@ import ProfileEditModal from './ProfileEditModal';
 
 interface TeamProfileEditButtonProps {
   profileId: string;
-  profileName?: string;
 }
 
 export default function TeamProfileEditButton({
   profileId,
-  profileName,
 }: TeamProfileEditButtonProps) {
   const currentUser = useCurrentUser();
   const { openModal, closeModal } = useModal();
@@ -25,11 +23,6 @@ export default function TeamProfileEditButton({
   }
 
   const handleProfileEdit = useCallback(async () => {
-    if (!currentUser?.id) {
-      console.error('User not logged in');
-      return;
-    }
-
     openModal(
       <ProfileEditModal
         config={teamProfileConfig}
@@ -39,7 +32,7 @@ export default function TeamProfileEditButton({
         onClose={closeModal}
       />,
     );
-  }, [profileId, currentUser?.id, openModal, closeModal]);
+  }, [profileId, openModal, closeModal]);
 
   return (
     <button

--- a/src/app/components/card/portfolio/TeamProfileEditButton.tsx
+++ b/src/app/components/card/portfolio/TeamProfileEditButton.tsx
@@ -19,11 +19,6 @@ export default function TeamProfileEditButton({
   const currentUser = useCurrentUser();
   const { openModal, closeModal } = useModal();
 
-  // 로그인하지 않은 경우 버튼을 렌더링하지 않음
-  if (!currentUser) {
-    return null;
-  }
-
   const handleProfileEdit = useCallback(async () => {
     if (!currentUser?.id) {
       console.error('User not logged in');
@@ -40,6 +35,11 @@ export default function TeamProfileEditButton({
       />,
     );
   }, [profileId, currentUser?.id, openModal, closeModal]);
+
+  // 로그인하지 않은 경우 버튼을 렌더링하지 않음
+  if (!currentUser) {
+    return null;
+  }
 
   return (
     <button


### PR DESCRIPTION
## 💡 개요
This pull request refactors the logic for rendering profile edit buttons, improving authorization checks and simplifying props in both `ProfileEditButton` and `TeamProfileEditButton`. The main focus is on preventing unauthorized users from seeing or interacting with the edit buttons, and cleaning up unused props and code.

## 📃 작업내용

**Authorization and rendering improvements:**

* The edit buttons in both `ProfileEditButton` and `TeamProfileEditButton` are now only rendered if the current user is authorized (i.e., the user is logged in and, for personal profiles, is the owner). Unauthorized users will not see the button at all. [[1]](diffhunk://#diff-cdeb15fb11f0d8d8d7d8fafdfad4d6a854dcc4a39cbc725c0cd342d9e1f13085L45-L54) [[2]](diffhunk://#diff-2e6ad73eb4a38a7c7a22c2d0daba2a0cb2c66df08806fe1ef1cd5efa54ffa42eL37-L46)

**Code simplification and cleanup:**

* Removed the unused `profileName` prop from both components and eliminated related logging code. [[1]](diffhunk://#diff-cdeb15fb11f0d8d8d7d8fafdfad4d6a854dcc4a39cbc725c0cd342d9e1f13085L13-L31) [[2]](diffhunk://#diff-2e6ad73eb4a38a7c7a22c2d0daba2a0cb2c66df08806fe1ef1cd5efa54ffa42eL12-L27)
* Simplified the dependency arrays in the `useCallback` hooks by removing unnecessary dependencies related to user ID and ownership checks. [[1]](diffhunk://#diff-cdeb15fb11f0d8d8d7d8fafdfad4d6a854dcc4a39cbc725c0cd342d9e1f13085L45-L54) [[2]](diffhunk://#diff-2e6ad73eb4a38a7c7a22c2d0daba2a0cb2c66df08806fe1ef1cd5efa54ffa42eL37-L46)
* Removed redundant authorization checks inside the edit handlers, since unauthorized users can no longer trigger the handlers. [[1]](diffhunk://#diff-cdeb15fb11f0d8d8d7d8fafdfad4d6a854dcc4a39cbc725c0cd342d9e1f13085L13-L31) [[2]](diffhunk://#diff-2e6ad73eb4a38a7c7a22c2d0daba2a0cb2c66df08806fe1ef1cd5efa54ffa42eL12-L27) *
## 🔀 변경사항

## 📸 스크린샷
