### PR TITLE
(i25 265) feat/사이드바에 등록된 내용이 없으면 없다 표시하기

### DIFF
--- a/src/app/components/card/portfolio/components/PortfolioDetail.tsx
+++ b/src/app/components/card/portfolio/components/PortfolioDetail.tsx
@@ -21,18 +21,29 @@ interface PortfolioDetailProps {
 const PortfolioDetail = ({ details }: PortfolioDetailProps) => {
   return (
     <div className="p-4 bg-light-gray-outline rounded-lg flex-col gap-10">
-      {details.map(({ mode, datas }) => (
+      {details.map(({ mode, datas }) => {
+        const hasData = datas.length > 0;
+        const skillIds =
+          mode === 'skill'
+            ? datas
+                .map((data) => ('skillId' in data ? data.skillId : undefined))
+                .filter((id): id is number => id !== undefined)
+            : [];
+
+        return (
         <div key={mode}>
           <Label>{modeTextMap[mode]}</Label>
           {mode === 'skill' ? (
+              skillIds.length > 0 ? (
             <SkillTagProvider
               readOnly
               white
-              initialTags={datas
-                .map((data) => ('skillId' in data ? data.skillId : undefined))
-                .filter((id): id is number => id !== undefined)}
+                  initialTags={skillIds}
             />
           ) : (
+                <Label className="text-detail !block">등록된 정보가 없습니다.</Label>
+              )
+            ) : hasData ? (
             <div className="flex-col">
               {datas.map((data, index) => (
                 <ProfileItem
@@ -44,9 +55,12 @@ const PortfolioDetail = ({ details }: PortfolioDetailProps) => {
                 />
               ))}
             </div>
+            ) : (
+              <Label className="text-detail !block">등록된 정보가 없습니다.</Label>
           )}
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/src/app/components/project/sidebar/ProjectSummarySection.tsx
+++ b/src/app/components/project/sidebar/ProjectSummarySection.tsx
@@ -139,14 +139,14 @@ export const ProjectLinkSection = ({ links }: ProjectLinkSectionProps) => (
             rel="noopener noreferrer"
             className="text-detail cursor-pointer hover:underline"
           >
-            <Label className="text-detail">
+            <Label className="text-detail !block">
               {link.title || link.url}
             </Label>
           </a>
         ))}
       </div>
     ) : (
-      <Label className="text-detail">등록된 링크가 없습니다.</Label>
+      <Label className="text-detail !block">등록된 정보가 없습니다.</Label>
     )}
   </section>
 );
@@ -159,6 +159,10 @@ export const ProjectTechnologiesSection = ({
 }) => (
   <section className="flex-col gap-[0.375rem]">
     <Label>기술스택</Label>
+    {technologies.length > 0 ? (
     <SkillTagProvider readOnly initialTags={technologies} />
+    ) : (
+      <Label className="text-detail !block">등록된 정보가 없습니다.</Label>
+    )}
   </section>
 );

--- a/src/app/components/project/sidebar/ProjectTeamSection.tsx
+++ b/src/app/components/project/sidebar/ProjectTeamSection.tsx
@@ -48,7 +48,7 @@ export const ProjectTeamSection = ({
               <TeamMemberItem key={member.id} member={member} />
             ))
           ) : (
-            <Label className="text-detail">참여자 정보가 없습니다.</Label>
+            <Label className="text-detail !block">등록된 정보가 없습니다.</Label>
           )}
         </div>
       </div>

--- a/src/services/graphQL/dataTransformer.graphql.ts
+++ b/src/services/graphQL/dataTransformer.graphql.ts
@@ -289,9 +289,7 @@ export function formDataToGraphQL(
               return obj;
             });
 
-          if (relationItems.length > 0) {
-            relationTableData.set(table, relationItems);
-          }
+          relationTableData.set(table, relationItems);
         } else {
           // 빈 배열일 때도 relationTableData에 빈 배열 설정 (삭제 처리용)
           relationTableData.set(table, []);

--- a/src/utils/hook/useInputList.ts
+++ b/src/utils/hook/useInputList.ts
@@ -40,17 +40,36 @@ export const useInputList = (initialConfig?: MultiInputItem[] | MultiInputItem[]
       case 'SET_ACTIVE': {
         if (draft.activeIndex === action.index) return
         
-        const shouldRemoveEmpty = draft.activeIndex !== null && 
-          isInputEmpty(draft.inputs[draft.activeIndex])
+        // 새로운 activeIndex를 계산하기 위한 변수
+        let newActiveIndex = action.index
         
+        // activeIndex가 null이 아닐 때: 현재 활성화된 인풋이 비어있으면 제거
+        if (draft.activeIndex !== null) {
+          const shouldRemoveEmpty = isInputEmpty(draft.inputs[draft.activeIndex])
         if (shouldRemoveEmpty) {
           const removedIndex = draft.activeIndex!
           draft.inputs.splice(removedIndex, 1)
-          if (action.index != null && action.index > removedIndex) {
-            action.index--
+            if (newActiveIndex != null && newActiveIndex > removedIndex) {
+              newActiveIndex--
+            }
           }
         }
-        draft.activeIndex = action.index
+        
+        // activeIndex가 null일 때: 클릭된 인덱스가 아닌 다른 빈 인풋들 제거
+        // 0번 인풋이 비어있을 때 다른 인풋을 클릭하면 0번 인풋이 제거되어야 함
+        if (draft.activeIndex === null && newActiveIndex !== null) {
+          // 역순으로 순회하여 인덱스 변경에 영향 없이 제거
+          for (let i = draft.inputs.length - 1; i >= 0; i--) {
+            if (i !== newActiveIndex && isInputEmpty(draft.inputs[i])) {
+              draft.inputs.splice(i, 1)
+              if (newActiveIndex > i) {
+                newActiveIndex--
+          }
+        }
+          }
+        }
+        
+        draft.activeIndex = newActiveIndex
         break
       }
       


### PR DESCRIPTION
## 💡 개요
사이드바에서 링크, 자격증, 수상이력, 기술스택 등이 비어있을 때 사용자에게 명확한 안내 메시지를 표시하도록 개선했습니다. 또한 멀티인풋 컴포넌트의 빈 인풋 자동 제거 로직을 개선하고, 모든 값이 비어있을 때 DB에서 삭제가 정상적으로 처리되도록 수정했습니다.

## 📃 작업내용

### 1. 사이드바 빈 상태 메시지 표시
프로젝트 사이드바와 포트폴리오 사이드바에서 데이터가 없을 때 "등록된 정보가 없습니다." 메시지를 Label 컴포넌트의 그레이 색상으로 표시하도록 구현했습니다.

```mermaid
graph TD
    A[사이드바 섹션] --> B{데이터 존재 여부}
    B -->|있음| C[데이터 표시]
    B -->|없음| D[Label 컴포넌트]
    D --> E[text-detail 클래스]
    E --> F["등록된 정보가 없습니다."]
    
    G[ProjectLinkSection] --> A
    H[ProjectTechnologiesSection] --> A
    I[ProjectTeamSection] --> A
    J[PortfolioDetail] --> A
```

### 2. useInputList 빈 인풋 자동 제거 로직 개선
0번째 인풋이 비어있을 때 다른 인풋을 클릭하면 0번째 인풋이 자동으로 제거되도록 로직을 개선했습니다.

```mermaid
graph LR
    A[사용자 클릭] --> B[SET_ACTIVE 액션]
    B --> C{activeIndex 상태}
    C -->|null| D[빈 인풋 검사]
    C -->|not null| E[현재 활성 인풋 검사]
    D --> F[클릭된 인덱스 제외 빈 인풋 제거]
    E --> G{현재 인풋이 비어있음?}
    G -->|예| H[현재 인풋 제거]
    G -->|아니오| I[인덱스 유지]
    F --> J[새 인덱스 설정]
    H --> J
```

### 3. 멀티인풋 빈 배열 DB 삭제 처리
모든 값이 비어있을 때도 relationTableData에 빈 배열을 설정하여 DB에서 삭제가 정상적으로 처리되도록 수정했습니다.

```mermaid
graph TD
    A[formDataToGraphQL] --> B{InputList 타입?}
    B -->|예| C[빈 항목 필터링]
    C --> D{relationItems.length}
    D -->|> 0| E[relationTableData.set]
    D -->|= 0| E
    E --> F[DB 삭제 처리]
```

## 🔀 변경사항

### 추가 작업
- **사이드바 빈 상태 처리**: 
  - `ProjectLinkSection`: 링크가 없을 때 메시지 표시
  - `ProjectTechnologiesSection`: 기술스택이 없을 때 메시지 표시
  - `ProjectTeamSection`: 기여자 정보가 없을 때 메시지 표시
  - `PortfolioDetail`: 링크, 자격증, 수상이력, 기술스택이 없을 때 메시지 표시
- **useInputList 개선**: 
  - `activeIndex`가 `null`일 때도 빈 인풋 자동 제거 로직 추가
  - immer의 `produce` 내에서 `action.index` 직접 수정 대신 `newActiveIndex` 변수 사용
- **dataTransformer 수정**: 
  - 모든 항목이 비어있어도 빈 배열을 `relationTableData`에 설정하여 DB 삭제 처리

### 개선 사항
- 사용자 경험 개선: 빈 상태에 대한 명확한 안내 메시지 제공
- 코드 품질: immer의 불변성 원칙 준수 및 인덱스 조정 로직 개선
- 데이터 일관성: 빈 배열도 정상적으로 DB에 반영되어 삭제 처리 보장

## 📸 스크린샷
<img width="565" height="544" alt="image" src="https://github.com/user-attachments/assets/2bf0b6f0-99a6-4bf9-99d6-2eb136fdbd7b" />
