### PR TITLE
(i25 242) fix/project card responsive

### DIFF
--- a/src/app/(box-layout)/team/Team.tsx
+++ b/src/app/(box-layout)/team/Team.tsx
@@ -1,11 +1,10 @@
 'use server';
 import { getTeamData } from '@/services/team/getTeamData.server';
 import { getTeamProjects } from '@/services/team/getTeamProjects.server';
-import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
 import { notFound } from 'next/navigation';
 import TeamSidebar from './TeamSidebar';
-import Card from '@/app/components/card/project/ProjectCard';
 import ProfileIcon from '@/app/components/card/portfolio/ProfileIcon';
+import ProjectGrid from '@/app/components/project/components/ProjectGrid';
 
 const Team = async ({ teamName }: { teamName: string }) => {
   const teamDetail = (await getTeamData(teamName)) ?? notFound();
@@ -16,27 +15,11 @@ const Team = async ({ teamName }: { teamName: string }) => {
       <ProfileIcon image={teamDetail.profile_image} />
       <TeamSidebar teamDetail={teamDetail} projectCount={teamProjects.length} />
       <section className="w-full">
-        <div className="pl-[3rem] pt-[4.5rem] grid grid-cols-auto-fit-card gap-6 responsive-teamProjects">
-          {teamProjects.map((project) => (
-            <Card
-              key={project.project_id}
-              id={project.project_id}
-              title={project.project_name}
-              description={project.description}
-              ownerName={project.profile.profile_name}
-              projectImage={convertFromDatabaseImageURL(
-                project.project_thumbnail,
-              )}
-              isTeam={project.profile.is_team}
-              authors={project.project_contributors.map((contributor) => ({
-                name: contributor.profile.profile_name,
-                profileImage: convertFromDatabaseImageURL(
-                  contributor.profile.profile_image,
-                ),
-              }))}
-            />
-          ))}
-        </div>
+        <ProjectGrid
+          projects={teamProjects}
+          className="pl-[3rem] pt-[4.5rem] responsive-teamProjects"
+          isTeamProject={true}
+        />
       </section>
     </div>
   );

--- a/src/app/components/HomeProjectList.tsx
+++ b/src/app/components/HomeProjectList.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
-import ProjectCard from '@/app/components/card/project/ProjectCard';
 import CategoryTag from '@/app/components/contents/CategoryTag';
 import { CardProps } from '@/app/components/card/project/ProjectCard';
+import ProjectGrid from './project/components/ProjectGrid';
 
 interface HomeProjectListProps {
   projects: CardProps[];
@@ -49,20 +49,7 @@ export default function HomeProjectList({ projects }: HomeProjectListProps) {
       </div>
 
       {/* 프로젝트 그리드 */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
-        {filteredProjects.map((project) => (
-          <ProjectCard
-            key={project.id}
-            id={project.id}
-            title={project.title}
-            description={project.description}
-            isTeam={project.isTeam}
-            ownerName={project.ownerName}
-            projectImage={project.projectImage}
-            authors={project.authors}
-          />
-        ))}
-      </div>
+      <ProjectGrid projects={filteredProjects} />
     </div>
   );
 }

--- a/src/app/components/card/portfolio/PortfolioHome.tsx
+++ b/src/app/components/card/portfolio/PortfolioHome.tsx
@@ -1,10 +1,10 @@
 import PortfolioItems from './components/PortfolioDetail';
 import { Title } from '../../system/text';
-import Card from '../project/ProjectCard';
 
 import { PortfolioDetailProps } from '@/app/(box-layout)/portfolio/types';
 import { CardProps } from '@/app/components/card/project/ProjectCard';
 import ProfileEditButton from './ProfileEditButton';
+import ProjectGrid from '../../project/components/ProjectGrid';
 
 interface PortfolioHomeProps {
   content: string;
@@ -30,20 +30,7 @@ const PortfolioHome = ({
         <div>{content}</div>
         <div>
           <Title>개인 프로젝트</Title>
-          <div className="mt-2 grid gap-6 grid-cols-auto-fit-card portfolioHomeCard">
-            {projects.map((data) => (
-              <Card
-                key={data.id}
-                id={data.id}
-                title={data.title}
-                description={data.description}
-                projectImage={data.projectImage}
-                ownerName={data.ownerName}
-                isTeam={data.isTeam}
-                authors={data.authors}
-              />
-            ))}
-          </div>
+          <ProjectGrid projects={projects} className="mt-2 portfolioHomeCard" />
         </div>
       </section>
     </>

--- a/src/app/components/card/portfolio/components/ProjectImages.tsx
+++ b/src/app/components/card/portfolio/components/ProjectImages.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
 import { Project } from '../types';
+import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
 
 interface ProjectImagesProps {
   projects: Project[];
@@ -24,7 +25,7 @@ const ProjectImages = ({ projects, variant }: ProjectImagesProps) => {
         (project, index) => (
           <div className={imageClass} key={index}>
             <Image
-              src={project.projectImage}
+              src={convertFromDatabaseImageURL(project.projectImage)}
               alt={project.title}
               fill
               className="object-cover rounded"

--- a/src/app/components/card/project/ProjectCard.tsx
+++ b/src/app/components/card/project/ProjectCard.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import MetaInfo from './MetaInfo';
 import Link from 'next/link';
 import { converIsTeamToUrl } from '@/utils/convertIsTeamToUrl';
+import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
 
 export interface CardProps {
   id: number;
@@ -35,7 +36,7 @@ const Card = ({
       <div className="w-full mobile:max-w-full mobile:min-w-[26rem] max-w-[26rem] flex-col gap-[0.375rem]">
         <figure className="relative h-60 mobile:h-80 aspect-video rounded-[0.25rem] overflow-hidden">
           <Image
-            src={projectImage}
+            src={convertFromDatabaseImageURL(projectImage)}
             alt={`${title || ownerName} 프로젝트 이미지`}
             fill
             className="object-cover"

--- a/src/app/components/card/root/AutoSlidingBusinessCard.tsx
+++ b/src/app/components/card/root/AutoSlidingBusinessCard.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { useInfinitePortfolio } from '@/utils/hook/useInfinitePortfolio';
 import { PortfolioData } from '@/app/(box-layout)/portfolio/types';
 import BusinessCard, { BusinessCardData } from './BusinessCard';
+import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
 
 const SLIDE_INTERVAL = 1500;
 const DEFAULT_AVATAR = '/default-avatar.svg';
@@ -35,16 +36,19 @@ const DEFAULT_CARDS: BusinessCardData[] = [
   },
 ];
 
-const convertPortfolioToBusinessCard = (portfolio: PortfolioData): BusinessCardData => ({
+const convertPortfolioToBusinessCard = (
+  portfolio: PortfolioData,
+): BusinessCardData => ({
   id: portfolio.profile.name,
   name: portfolio.student?.name || portfolio.profile.name,
-  department: portfolio.student?.department?.department_name || '학과 정보 없음',
-  profileImage: portfolio.profile.profile_image,
+  department:
+    portfolio.student?.department?.department_name || '학과 정보 없음',
+  profileImage: convertFromDatabaseImageURL(portfolio.profile.profile_image),
   profileName: portfolio.profile.name,
   projects: portfolio.projects.slice(0, 3).map((project, i) => ({
     id: `${portfolio.profile.name}-${i}`,
     title: project.title,
-    image: project.projectImage || DEFAULT_AVATAR,
+    image: convertFromDatabaseImageURL(project.projectImage) || DEFAULT_AVATAR,
   })),
 });
 
@@ -52,16 +56,16 @@ const AutoSlidingBusinessCard = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isHovered, setIsHovered] = useState(false);
   const { data, isLoading, error, loadMore } = useInfinitePortfolio();
-  
-  const displayCards = data.length > 0 
-    ? data.map(convertPortfolioToBusinessCard)
-    : DEFAULT_CARDS;
+
+  const displayCards =
+    data.length > 0 ? data.map(convertPortfolioToBusinessCard) : DEFAULT_CARDS;
 
   useEffect(() => {
     if (displayCards.length === 0) return;
 
     const interval = setInterval(() => {
-      if (!isHovered) { // 호버 중이 아닐 때만 슬라이딩
+      if (!isHovered) {
+        // 호버 중이 아닐 때만 슬라이딩
         setCurrentIndex((prev) => {
           const nextIndex = (prev + 1) % displayCards.length;
           if (nextIndex === 0 && !isLoading) loadMore();
@@ -90,15 +94,15 @@ const AutoSlidingBusinessCard = () => {
   }
 
   return (
-    <article 
+    <article
       className="relative flex items-center justify-center h-full w-[26rem] mobile:w-full mobile:h-[15rem] bg-[#D7EFFF] rounded-[0.25rem] overflow-hidden"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <Image 
-        src="/card/AutoSlidingBusinessCard/bottom.svg" 
-        alt="bottom" 
-        width={139} 
+      <Image
+        src="/card/AutoSlidingBusinessCard/bottom.svg"
+        alt="bottom"
+        width={139}
         height={200}
         className="absolute left-[calc(7.5/17*100%)] top-[5px] -translate-x-1/2 z-0"
         priority
@@ -133,6 +137,5 @@ const AutoSlidingBusinessCard = () => {
     </article>
   );
 };
-
 
 export default AutoSlidingBusinessCard;

--- a/src/app/components/project/components/ProjectGrid.tsx
+++ b/src/app/components/project/components/ProjectGrid.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { CardProps } from '@/app/components/card/project/ProjectCard';
+import Card from '@/app/components/card/project/ProjectCard';
+import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
+import type { TeamProjectType } from '@/app/(box-layout)/team/types';
+
+interface ProjectGridProps {
+  projects: CardProps[] | TeamProjectType[];
+  className?: string;
+  isTeamProject?: boolean;
+}
+
+const ProjectGrid = ({
+  projects,
+  className,
+  isTeamProject = false,
+}: ProjectGridProps) => {
+  const transformedProjects: CardProps[] = projects.map((project) => {
+    if (isTeamProject) {
+      // TeamProjectType 변환
+      const teamProject = project as TeamProjectType;
+      return {
+        id: teamProject.project_id,
+        title: teamProject.project_name,
+        description: teamProject.description,
+        projectImage: convertFromDatabaseImageURL(
+          teamProject.project_thumbnail,
+        ),
+        ownerName: teamProject.profile.profile_name,
+        isTeam: teamProject.profile.is_team,
+        authors: teamProject.project_contributors.map((contributor) => ({
+          name: contributor.profile.profile_name,
+          profileImage: convertFromDatabaseImageURL(
+            contributor.profile.profile_image,
+          ),
+        })),
+      };
+    } else {
+      // CardProps 형식 그대로 사용
+      return project as CardProps;
+    }
+  });
+
+  return (
+    <div className={`grid gap-6 grid-cols-auto-fit-card ${className}`}>
+      {transformedProjects.map((data) => (
+        <Card
+          key={data.id}
+          id={data.id}
+          title={data.title}
+          description={data.description}
+          projectImage={data.projectImage}
+          ownerName={data.ownerName}
+          isTeam={data.isTeam}
+          authors={data.authors}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default ProjectGrid;

--- a/src/app/components/project/components/ProjectGrid.tsx
+++ b/src/app/components/project/components/ProjectGrid.tsx
@@ -2,7 +2,6 @@
 
 import { CardProps } from '@/app/components/card/project/ProjectCard';
 import Card from '@/app/components/card/project/ProjectCard';
-import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
 import type { TeamProjectType } from '@/app/(box-layout)/team/types';
 
 interface ProjectGridProps {
@@ -24,16 +23,12 @@ const ProjectGrid = ({
         id: teamProject.project_id,
         title: teamProject.project_name,
         description: teamProject.description,
-        projectImage: convertFromDatabaseImageURL(
-          teamProject.project_thumbnail,
-        ),
+        projectImage: teamProject.project_thumbnail,
         ownerName: teamProject.profile.profile_name,
         isTeam: teamProject.profile.is_team,
         authors: teamProject.project_contributors.map((contributor) => ({
           name: contributor.profile.profile_name,
-          profileImage: convertFromDatabaseImageURL(
-            contributor.profile.profile_image,
-          ),
+          profileImage: contributor.profile.profile_image,
         })),
       };
     } else {

--- a/src/services/portfolio/getPaginatedPortfolioData.server.ts
+++ b/src/services/portfolio/getPaginatedPortfolioData.server.ts
@@ -1,5 +1,4 @@
 import { createClient } from '@/services/supabase/client';
-import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
 import {
   PortfolioData,
   ProfileWithProjects,
@@ -105,23 +104,21 @@ export async function getPaginatedPortfolioData(
         role: data.student?.student_jobs?.map(({ job }) => job.job_name) || [],
         bio: data.description!,
         status: '구직 중',
-        profile_image: convertFromDatabaseImageURL(data.profile_image),
+        profile_image: data.profile_image,
       },
       student: data.student,
       projects: [
         ...(data.project_contributors?.map((contribution) => ({
           title: contribution.project.project_name,
-          logo: convertFromDatabaseImageURL(contribution.project.project_logo),
+          logo: contribution.project.project_logo,
           description: contribution.project.description,
-          projectImage: convertFromDatabaseImageURL(
-            contribution.project.project_thumbnail,
-          ),
+          projectImage: contribution.project.project_thumbnail,
         })) || []),
         ...data.projects?.map((project) => ({
           title: project.project_name,
-          logo: convertFromDatabaseImageURL(project.project_logo),
+          logo: project.project_logo,
           description: project.description,
-          projectImage: convertFromDatabaseImageURL(project.project_thumbnail),
+          projectImage: project.project_thumbnail,
         })),
       ],
     };

--- a/src/services/portfolio/getPersonalPortfolioData.server.ts
+++ b/src/services/portfolio/getPersonalPortfolioData.server.ts
@@ -1,5 +1,4 @@
 import { createClient } from '@/services/supabase/client';
-import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
 import {
   PortfolioData,
   ProfileWithProjects,
@@ -70,23 +69,21 @@ export async function getPersonalPortfolioData(): Promise<PortfolioData[]> {
         role: data.student?.student_jobs?.map(({ job }) => job.job_name) || [],
         bio: data.description!,
         status: '구직 중',
-        profile_image: convertFromDatabaseImageURL(data.profile_image),
+        profile_image: data.profile_image,
       },
       student: data.student,
       projects: [
         ...(data.project_contributors?.map((contribution) => ({
           title: contribution.project.project_name,
-          logo: convertFromDatabaseImageURL(contribution.project.project_logo),
+          logo: contribution.project.project_logo,
           description: contribution.project.description,
-          projectImage: convertFromDatabaseImageURL(
-            contribution.project.project_thumbnail,
-          ),
+          projectImage: contribution.project.project_thumbnail,
         })) || []),
         ...data.projects?.map((project) => ({
           title: project.project_name,
-          logo: convertFromDatabaseImageURL(project.project_logo),
+          logo: project.project_logo,
           description: project.description,
-          projectImage: convertFromDatabaseImageURL(project.project_thumbnail),
+          projectImage: project.project_thumbnail,
         })),
       ],
     };

--- a/src/services/project/getCooperationProjects.server.ts
+++ b/src/services/project/getCooperationProjects.server.ts
@@ -3,7 +3,6 @@ import { createClient } from "@/services/supabase/server"
 import { PersonalProjectType } from '@/services/project/getPersonalProjects.server';
 import { CardProps } from "@/app/components/card/project/ProjectCard";
 import { Tables } from "@/services/supabase/database.types";
-import { convertFromDatabaseImageURL } from "@/services/supabase/imageHostConverter";
 
 type TeamProjectType = {
   projects: PersonalProjectType & {
@@ -76,14 +75,14 @@ export const getCooperationProjects = async (profile_id: string): Promise<CardPr
 
   const projects: CardProps[] = teamProjects.map(({ projects }) => {
     const authors = profileImages?.filter((img) => img.project_id === projects.project_id).map((img) => ({
-      profileImage: convertFromDatabaseImageURL(img.profile.profile_image)
+      profileImage: img.profile.profile_image,
     }))
 
     return {
       id: projects.project_id,
       title: projects.project_name,
       description: projects.description,
-      projectImage: convertFromDatabaseImageURL(projects.project_thumbnail),
+      projectImage: projects.project_thumbnail,
       ownerName: projects.profile.profile_name,
       isTeam: projects.profile.is_team,
       authors: authors

--- a/src/services/project/getProjects.server.ts
+++ b/src/services/project/getProjects.server.ts
@@ -3,7 +3,6 @@
 import { createClient } from '@/services/supabase/server';
 import { CardProps } from '@/app/components/card/project/ProjectCard';
 import { Tables } from '@/services/supabase/database.types';
-import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
 import type { ProjectContributor, ProjectOwnerProfile } from '@/services/project/types';
 import { createAuthorsFromProject } from '@/services/project/utils';
 
@@ -64,7 +63,7 @@ async function fetchProjects(limit?: number): Promise<CardProps[]> {
     (project) => ({
       id: project.project_id,
       title: project.project_name,
-      projectImage: convertFromDatabaseImageURL(project.project_thumbnail),
+      projectImage: project.project_thumbnail,
       category: project.project_category?.category_name,
       description: project.description,
       isTeam: project.profile.is_team,
@@ -138,7 +137,7 @@ export const getProjectsByProfileName = async (profileName: string, limit?: numb
     (project) => ({
       id: project.project_id,
       title: project.project_name,
-      projectImage: convertFromDatabaseImageURL(project.project_thumbnail),
+      projectImage: project.project_thumbnail,
       category: project.project_category?.category_name,
       description: project.description,
       isTeam: project.profile.is_team,


### PR DESCRIPTION
## 💡 개요
프로젝트 카드 렌더링을 위한 코드 리팩토링 작업으로, 중복되는 프로젝트 그리드 렌더링 로직을 통합하고 이미지 URL 변환 함수의 사용을 통일했습니다. 

## 📃 작업내용
- 새로운 `ProjectGrid` 컴포넌트를 `components/project` 디렉토리에 생성
- 개인 프로젝트 `CardProps`와 팀 프로젝트 `TeamProjectType` 두 가지 타입을 모두 지원

## 🔀 변경사항
- 분산되어 있던 `convertFromDatabaseImageURL` 함수 호출을 컴포넌트 렌더링 단계에서 수행하도록 변경