### PR TITLE
[I25-270] feat : MetaInfo에 기여자가 없으면 Owner 표기되도록 수정

### DIFF
--- a/src/services/project/getPersonalProjects.server.ts
+++ b/src/services/project/getPersonalProjects.server.ts
@@ -53,7 +53,10 @@ export const getPersonalProjects = async (profile_id: string): Promise<CardProps
     projectImage: convertFromDatabaseImageURL(project.project_thumbnail),
     ownerName: project.profile.profile_name,
     isTeam: project.profile.is_team,
-    authors: createAuthorsFromProject(project),
+    authors: createAuthorsFromProject(project, {
+      profile_name: project.profile.profile_name,
+      profile_image: project.profile.profile_image,
+    }),
   }));
 
   return projects || [];

--- a/src/services/project/getProjects.server.ts
+++ b/src/services/project/getProjects.server.ts
@@ -69,7 +69,10 @@ async function fetchProjects(limit?: number): Promise<CardProps[]> {
       description: project.description,
       isTeam: project.profile.is_team,
       ownerName: project.profile.profile_name,
-      authors: createAuthorsFromProject(project),
+      authors: createAuthorsFromProject(project, {
+        profile_name: project.profile.profile_name,
+        profile_image: project.profile.profile_image,
+      }),
     }),
   );
 
@@ -143,7 +146,10 @@ export const getProjectsByProfileName = async (profileName: string, limit?: numb
       description: project.description,
       isTeam: project.profile.is_team,
       ownerName: project.profile.profile_name,
-      authors: createAuthorsFromProject(project),
+      authors: createAuthorsFromProject(project, {
+        profile_name: project.profile.profile_name,
+        profile_image: project.profile.profile_image,
+      }),
     }),
   );
 

--- a/src/services/project/types.d.ts
+++ b/src/services/project/types.d.ts
@@ -35,4 +35,4 @@ export type ProjectContributor = Tables<'project_contributors'> & {
   profile: Pick<Tables<'profile'>, 'profile_id' | 'profile_image' | 'profile_name'> | null;
 };
 
-export type ProjectOwnerProfile = Pick<Tables<'profile'>, 'profile_id' | 'profile_name' | 'is_team'>;
+export type ProjectOwnerProfile = Pick<Tables<'profile'>, 'profile_id' | 'profile_name' | 'profile_image' | 'is_team'>;

--- a/src/services/project/utils.ts
+++ b/src/services/project/utils.ts
@@ -5,18 +5,36 @@ export type ProjectWithContributors = {
   project_contributors: ProjectContributor[];
 };
 
+type OwnerInfo = {
+  profile_name: string;
+  profile_image: string | null;
+};
+
 export function createAuthorsFromProject(
   project: ProjectWithContributors,
+  owner?: OwnerInfo,
 ): Array<{ name?: string; profileImage: string }> {
-  return (
-    project.project_contributors
-      ?.filter((contributor) => contributor.profile !== null)
-      .map((contributor) => ({
-        name: contributor.profile!.profile_name,
-        profileImage: convertFromDatabaseImageURL(
-          contributor.profile!.profile_image,
-        ),
-      })) || []
-  );
+  const contributors = project.project_contributors
+    ?.filter((contributor) => contributor.profile !== null)
+    .map((contributor) => ({
+      name: contributor.profile!.profile_name,
+      profileImage: convertFromDatabaseImageURL(
+        contributor.profile!.profile_image,
+      ),
+    })) || [];
+
+  // 기여자가 없고 owner 정보가 있으면 owner를 반환
+  if (contributors.length === 0 && owner) {
+    return [
+      {
+        name: owner.profile_name,
+        profileImage: owner.profile_image
+          ? convertFromDatabaseImageURL(owner.profile_image)
+          : '',
+      },
+    ];
+  }
+
+  return contributors;
 }
 


### PR DESCRIPTION
## 💡 개요
프로젝트 카드의 MetaInfo 컴포넌트에서 기여자(contributor)가 없는 경우에도 Owner 정보를 표시하도록 개선했습니다. 이를 통해 모든 프로젝트 카드에서 작성자 정보가 항상 표시되어 사용자 경험이 향상됩니다.

## 📃 작업내용
`createAuthorsFromProject` 함수에 owner 정보를 옵셔널 파라미터로 추가하고, 기여자가 없을 때 owner를 반환하는 fallback 로직을 구현했습니다.

```mermaid
flowchart TD
    A[createAuthorsFromProject 호출] --> B{기여자 존재?}
    B -->|Yes| C[기여자 정보 반환]
    B -->|No| D{Owner 정보 제공?}
    D -->|Yes| E[Owner 정보 반환]
    D -->|No| F[빈 배열 반환]
    C --> G[MetaInfo 컴포넌트 렌더링]
    E --> G
    F --> G
```

**주요 변경사항:**
1. `createAuthorsFromProject` 함수에 `owner` 옵셔널 파라미터 추가
2. 기여자가 없고 owner 정보가 제공된 경우 owner를 authors 배열로 반환
3. `getProjects.server.ts`와 `getPersonalProjects.server.ts`에서 owner 정보 전달
4. `ProjectOwnerProfile` 타입에 `profile_image` 필드 추가

## 🔀 변경사항
- `ProjectOwnerProfile` 타입 정의에 `profile_image` 필드를 추가하여 owner의 프로필 이미지 정보를 포함하도록 타입을 확장했습니다.


## 📸 스크린샷
<img width="2638" height="1721" alt="image" src="https://github.com/user-attachments/assets/39e03698-3b43-4028-8ccd-f74c636d106b" />
