### PR TITLE
I25-293: 메인 페이지 프로젝트 셔플

### DIFF
--- a/src/app/components/HomeProjectList.tsx
+++ b/src/app/components/HomeProjectList.tsx
@@ -14,12 +14,7 @@ export default function HomeProjectList({ projects }: HomeProjectListProps) {
   const [selectedCategory, setSelectedCategory] = useState<'All' | string>(
     'All',
   );
-  const [shuffledProjects, setShuffledProjects] = useState<CardProps[]>([]);
-
-  // 컴포넌트 마운트 시 프로젝트를 셔플
-  useEffect(() => {
-    setShuffledProjects(shuffleArray(projects));
-  }, [projects]);
+  const shuffledProjects = useMemo(() => shuffleArray(projects), [projects]);
 
   const categories = useMemo(() => {
     const uniqueCategories = new Set<string>();

--- a/src/app/components/HomeProjectList.tsx
+++ b/src/app/components/HomeProjectList.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import CategoryTag from '@/app/components/contents/CategoryTag';
 import { CardProps } from '@/app/components/card/project/ProjectCard';
 import ProjectGrid from './project/components/ProjectGrid';
+import { shuffleArray } from '@/utils/shuffle';
 
 interface HomeProjectListProps {
   projects: CardProps[];
@@ -13,6 +14,12 @@ export default function HomeProjectList({ projects }: HomeProjectListProps) {
   const [selectedCategory, setSelectedCategory] = useState<'All' | string>(
     'All',
   );
+  const [shuffledProjects, setShuffledProjects] = useState<CardProps[]>([]);
+
+  // 컴포넌트 마운트 시 프로젝트를 셔플
+  useEffect(() => {
+    setShuffledProjects(shuffleArray(projects));
+  }, [projects]);
 
   const categories = useMemo(() => {
     const uniqueCategories = new Set<string>();
@@ -28,9 +35,11 @@ export default function HomeProjectList({ projects }: HomeProjectListProps) {
 
   const filteredProjects = useMemo(() => {
     return selectedCategory === 'All'
-      ? projects
-      : projects.filter((project) => project.category === selectedCategory);
-  }, [projects, selectedCategory]);
+      ? shuffledProjects
+      : shuffledProjects.filter(
+          (project) => project.category === selectedCategory,
+        );
+  }, [shuffledProjects, selectedCategory]);
 
   return (
     <div className="flex-col gap-[0.90625rem] w-full">

--- a/src/utils/shuffle.ts
+++ b/src/utils/shuffle.ts
@@ -1,0 +1,18 @@
+/**
+ * Fisher-Yates 알고리즘을 사용하여 배열을 랜덤하게 셔플합니다.
+ * 원본 배열은 변경되지 않으며, 셔플된 새 배열을 반환합니다.
+ *
+ * @template T 배열 요소의 타입
+ * @param array 셔플할 배열
+ * @returns 셔플된 새 배열
+ */
+export function shuffleArray<T>(array: T[]): T[] {
+  const shuffled = [...array];
+
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  return shuffled;
+}


### PR DESCRIPTION
## 💡 개요
메인 페이지의 프로젝트 목록을 매번 셔플하여 다양한 순서로 보여줍니다.

## 📃 작업내용
- 프로젝트 리스트 셔플 기능 구현
- HomeProjectList 컴포넌트에서 프로젝트 배열을 마운트 시마다 랜덤하게 섞어 렌더링
- 셔플 유틸리티 함수(`shuffleArray`) 추가

## 🔀 변경사항
- `src/app/components/HomeProjectList.tsx`: 셔플 로직 및 상태 추가, 필터링 기준 변경
- `src/utils/shuffle.ts`: Fisher-Yates 기반 셔플 함수 신규 작성

## 📸 스크린샷
(해당 없음)
