### PR TITLE
I25 294 포트폴리오에 표시되는 이름을 실명으로 변경

### DIFF
--- a/src/app/(box-layout)/portfolio/SearchTab.tsx
+++ b/src/app/(box-layout)/portfolio/SearchTab.tsx
@@ -145,6 +145,7 @@ export default function SearchTab({
               profile={data.profile}
               projects={data.projects}
               src={`/portfolio/${encodeURIComponent(data.profile.name)}`}
+              studentName={data.student?.name}
             />
           ))
         ) : (

--- a/src/app/components/card/home/AutoSlidingBusinessCard.tsx
+++ b/src/app/components/card/home/AutoSlidingBusinessCard.tsx
@@ -40,11 +40,12 @@ const convertPortfolioToBusinessCard = (
   portfolio: PortfolioData,
 ): BusinessCardData => ({
   id: portfolio.profile.name,
-  name: portfolio.student?.name || portfolio.profile.name,
+  name: portfolio.profile.name,
   department:
     portfolio.student?.department?.department_name || '학과 정보 없음',
   profileImage: convertFromDatabaseImageURL(portfolio.profile.profile_image),
   profileName: portfolio.profile.name,
+  studentName: portfolio.student?.name,
   projects: portfolio.projects.slice(0, 3).map((project, i) => ({
     id: `${portfolio.profile.name}-${i}`,
     title: project.title,

--- a/src/app/components/card/home/BusinessCard.tsx
+++ b/src/app/components/card/home/BusinessCard.tsx
@@ -17,6 +17,7 @@ interface BusinessCardData {
   profileImage: string;
   profileName: string;
   projects: ProjectItem[];
+  studentName?: string;
 }
 
 interface BusinessCardProps {
@@ -46,6 +47,8 @@ const ArrowIcon = () => (
 
 const ProfileHeader = ({ card }: { card: BusinessCardData }) => {
   const router = useRouter();
+  // 팀이 아닌 경우 studentName을 사용, 없으면 name 사용
+  const displayName = card.studentName || card.name;
 
   const handleClick = () => {
     router.push(`/portfolio/${card.profileName}`);
@@ -56,12 +59,12 @@ const ProfileHeader = ({ card }: { card: BusinessCardData }) => {
       <div className="flex gap-[7px] grow items-center">
         <ProfileImage
           src={card.profileImage}
-          name={card.name}
+          name={displayName}
           size={{ width: 27, height: 27 }}
         />
         <div className="flex flex-col grow items-start leading-[1.25] text-[#24292f]">
           <p className="font-bold text-[12px] tracking-[-0.8px] w-full">
-            {card.name}
+            {displayName}
           </p>
           <p className="font-normal text-[7px] tracking-[-0.5px] w-full">
             {card.department}

--- a/src/app/components/card/home/BusinessCardHolder.tsx
+++ b/src/app/components/card/home/BusinessCardHolder.tsx
@@ -75,6 +75,7 @@ const BusinessCardHolder = () => {
                       src={`/portfolio/${encodeURIComponent(
                         portfolio.profile.name,
                       )}`}
+                      studentName={portfolio.student?.name}
                     />
                   </div>
                 </div>

--- a/src/app/components/card/portfolio/PortfolioCard.tsx
+++ b/src/app/components/card/portfolio/PortfolioCard.tsx
@@ -6,7 +6,9 @@ import StatusBadge from '@/app/components/ui/badge/StatusBadge';
 import ProjectImages from '@/app/components/ui/profile/portfolio/ProjectImages';
 import ProfileImage from '@/app/components/ui/profile/ProfileImage';
 
-const PortfolioCard = ({ profile, projects, src }: PortfolioCardProps) => {
+const PortfolioCard = ({ profile, projects, src, studentName }: PortfolioCardProps) => {
+  // 팀이 아닌 경우 studentName을 사용, 없으면 profile.name 사용
+  const displayName = studentName || profile.name;
   const content = (
     <div className="@container w-full h-fit rounded border border-light-gray-outline bg-white p-4"
        style={{
@@ -25,10 +27,10 @@ const PortfolioCard = ({ profile, projects, src }: PortfolioCardProps) => {
         <div className="relative pl-2 -top-7 w-full">
           <ProfileImage
             src={profile.profile_image}
-            name={profile.name}
+            name={displayName}
             size="small"
           />
-          <ProfileInfo profile={profile} layout="horizontal" />
+          <ProfileInfo profile={{ ...profile, name: displayName }} layout="horizontal" />
           <StatusBadge
             status={profile.status}
             className="absolute top-12 right-0"
@@ -41,14 +43,14 @@ const PortfolioCard = ({ profile, projects, src }: PortfolioCardProps) => {
         {/* Profile Image */}
         <ProfileImage
           src={profile.profile_image}
-          name={profile.name}
+          name={displayName}
           size="small"
         />
 
         <div className="flex-col gap-2 flex-1 w-[calc(100%-0.625rem-45px)]">
           {/* Profile Info */}
           <div className="flex-1 relative">
-            <ProfileInfo profile={profile} layout="horizontal" />
+            <ProfileInfo profile={{ ...profile, name: displayName }} layout="horizontal" />
             <StatusBadge
               status={profile.status}
               className="absolute top-0 right-0"

--- a/src/app/components/card/portfolio/types.d.ts
+++ b/src/app/components/card/portfolio/types.d.ts
@@ -19,4 +19,5 @@ export interface PortfolioCardProps {
   projects: Project[];
   src?: string;
   isOfficial?: boolean;
+  studentName?: string;
 }

--- a/src/services/portfolio/getPaginatedPortfolioData.server.ts
+++ b/src/services/portfolio/getPaginatedPortfolioData.server.ts
@@ -54,7 +54,7 @@ export async function getPaginatedPortfolioData(
           status
         )
       ),
-      profile_owner_fkey1(
+      student!profile_owner_fkey1(
         name,
         join_at,
         graduate_at,


### PR DESCRIPTION
## 💡 개요

포트폴리오 카드 컴포넌트들이 개인 프로필의 경우 `profile_name` 대신 실제 학생 이름(`student_name`)을 표시하도록 개선했습니다. 이를 통해 사용자가 포트폴리오를 탐색할 때 더 직관적으로 학생을 식별할 수 있게 되었습니다.

기존에는 모든 포트폴리오 카드에서 `profile_name`(프로필 URL에 사용되는 이름)을 표시했으나, 이제 개인 포트폴리오는 실제 학생 이름을 표시하고 팀 포트폴리오는 팀 이름을 표시합니다.

## 📃 작업내용

### 주요 구현 사항

1. **타입 정의 확장**
   - `PortfolioCardProps`에 `studentName` 옵션 필드 추가
   - `BusinessCardData`에 `studentName` 옵션 필드 추가

2. **컴포넌트 로직 개선**
   - `PortfolioCard`: studentName이 있으면 이를 우선 표시, 없으면 profile.name 사용
   - `BusinessCard`: 동일한 로직 적용
   - `ProfileImage`와 `ProfileInfo` 컴포넌트에 올바른 이름 전달

3. **데이터 전달 체인 구축**
   - SearchTab → PortfolioCard에 studentName 전달
   - BusinessCardHolder → PortfolioCard에 studentName 전달
   - AutoSlidingBusinessCard의 변환 함수에서 studentName 설정

4. **API 버그 수정**
   - `getPaginatedPortfolioData.server.ts`에서 student 데이터 alias 누락 수정
   - `profile_owner_fkey1` → `student!profile_owner_fkey1`로 변경하여 student 데이터 올바르게 접근

### 시스템 흐름도

```mermaid
graph TB
    A[Supabase Query] --> B{student alias 설정}
    B --> C[student!profile_owner_fkey1]
    C --> D[PortfolioData with student.name]
    
    D --> E[SearchTab]
    D --> F[BusinessCardHolder]
    D --> G[AutoSlidingBusinessCard]
    
    E --> H[PortfolioCard]
    F --> H
    G --> I[BusinessCard]
    
    H --> J{studentName 존재?}
    I --> K{studentName 존재?}
    
    J -->|Yes| L[student.name 표시]
    J -->|No| M[profile.name 표시]
    
    K -->|Yes| N[student.name 표시]
    K -->|No| O[profile.name 표시]
```

### 핵심 로직

#### 1. PortfolioCard 표시 로직
```typescript
const PortfolioCard = ({ profile, projects, src, studentName }) => {
  // 팀이 아닌 경우 studentName을 사용, 없으면 profile.name 사용
  const displayName = studentName || profile.name;
  
  return (
    <ProfileImage name={displayName} />
    <ProfileInfo profile={{ ...profile, name: displayName }} />
  );
};
```

#### 2. 데이터 전달
```typescript
// SearchTab.tsx
<PortfolioCard
  profile={data.profile}
  projects={data.projects}
  studentName={data.student?.name}  // 학생 실명 전달
/>

// AutoSlidingBusinessCard.tsx
const convertPortfolioToBusinessCard = (portfolio) => ({
  name: portfolio.profile.name,
  studentName: portfolio.student?.name,  // 학생 실명 설정
  ...
});
```

## 🔀 변경사항

### 수정된 파일

#### 타입 정의
- `src/app/components/card/portfolio/types.d.ts`: PortfolioCardProps에 studentName 필드 추가

#### 컴포넌트
- `src/app/components/card/portfolio/PortfolioCard.tsx`: studentName prop 받아서 displayName으로 사용
- `src/app/(box-layout)/portfolio/SearchTab.tsx`: studentName 전달
- `src/app/components/card/home/BusinessCardHolder.tsx`: studentName 전달
- `src/app/components/card/home/BusinessCard.tsx`: studentName 필드 추가 및 사용
- `src/app/components/card/home/AutoSlidingBusinessCard.tsx`: 변환 함수에서 studentName 설정

#### API/서비스
- `src/services/portfolio/getPaginatedPortfolioData.server.ts`: **[버그 수정]** student alias 누락 수정

### 주요 변경 포인트

1. **타입 안전성**: TypeScript 인터페이스에 studentName 필드 명시적으로 추가
2. **일관성**: 모든 포트폴리오 카드 컴포넌트에서 동일한 로직 적용
3. **하위 호환성**: studentName이 없는 경우(팀 프로필) 기존 동작 유지
4. **버그 수정**: Supabase query에서 student 데이터를 올바르게 가져오도록 alias 수정

### 영향 범위

- ✅ 포트폴리오 검색 페이지 (SearchTab)
- ✅ 최근 본 포트폴리오 목록 (BusinessCardHolder)
- ✅ 홈 화면 슬라이딩 명함 (AutoSlidingBusinessCard)
- ✅ 팀 프로필은 기존대로 팀 이름 표시 (studentName이 없으므로)

### 개선 효과

- 👤 사용자가 포트폴리오 탐색 시 실제 학생 이름을 볼 수 있어 더 직관적
- 🔍 검색 결과에서 학생 식별이 용이
- 🎯 profile_name과 student_name의 역할 분리 명확화
- 🐛 API에서 student 데이터를 가져오지 못하던 버그 수정

## 📸 스크린샷
<img width="699" height="393" alt="image" src="https://github.com/user-attachments/assets/0c72069e-d85b-4469-8d6f-ccbc123a66a6" />
<img width="423" height="1636" alt="image" src="https://github.com/user-attachments/assets/896475ff-8087-4508-9f5d-b63581f2f672" />

