### PR TITLE
[I25-297] feat: update BusinessCard to utilize studentName for display

### DIFF
--- a/src/app/(box-layout)/team/types.d.ts
+++ b/src/app/(box-layout)/team/types.d.ts
@@ -10,6 +10,7 @@ export type TeamData = MergeDeep<
     team_member: {
       profile: Pick<Tables<'profile'>, 'profile_id' | 'profile_name' | 'profile_image'>;
     }[];
+    projects?: Array<Pick<Tables<'projects'>, 'project_id' | 'project_name' | 'project_thumbnail' | 'description'>> | null;
   }
 >;
 

--- a/src/app/components/card/home/BusinessCardHolder.tsx
+++ b/src/app/components/card/home/BusinessCardHolder.tsx
@@ -76,6 +76,7 @@ const BusinessCardHolder = () => {
                         portfolio.profile.name,
                       )}`}
                       studentName={portfolio.student?.name}
+                      maxProjects={1}
                     />
                   </div>
                 </div>

--- a/src/app/components/card/portfolio/PortfolioCard.tsx
+++ b/src/app/components/card/portfolio/PortfolioCard.tsx
@@ -6,7 +6,7 @@ import StatusBadge from '@/app/components/ui/badge/StatusBadge';
 import ProjectImages from '@/app/components/ui/profile/portfolio/ProjectImages';
 import ProfileImage from '@/app/components/ui/profile/ProfileImage';
 
-const PortfolioCard = ({ profile, projects, src, studentName }: PortfolioCardProps) => {
+const PortfolioCard = ({ profile, projects, src, studentName, maxProjects }: PortfolioCardProps) => {
   // 팀이 아닌 경우 studentName을 사용, 없으면 profile.name 사용
   const displayName = studentName || profile.name;
   const content = (
@@ -20,8 +20,8 @@ const PortfolioCard = ({ profile, projects, src, studentName }: PortfolioCardPro
         className="@[450px]:hidden w-full h-fit flex-col flex-center"
 
       >
-        {/* Project Images Header */}
-        <ProjectImages projects={projects} variant="default" />
+        {/* Project Images Header - 모바일은 최대 3개 */}
+        <ProjectImages projects={projects} variant="default" maxProjects={maxProjects ?? 3} />
 
         {/* Profile Section */}
         <div className="relative pl-2 -top-7 w-full">
@@ -57,9 +57,9 @@ const PortfolioCard = ({ profile, projects, src, studentName }: PortfolioCardPro
             />
           </div>
 
-          {/* Project Images */}
+          {/* Project Images - 데스크톱은 무제한 */}
           {projects.length ? (
-            <ProjectImages projects={projects} variant="long" />
+            <ProjectImages projects={projects} variant="long" maxProjects={maxProjects} />
           ) : null}
         </div>
       </div>

--- a/src/app/components/card/portfolio/types.d.ts
+++ b/src/app/components/card/portfolio/types.d.ts
@@ -20,4 +20,5 @@ export interface PortfolioCardProps {
   src?: string;
   isOfficial?: boolean;
   studentName?: string;
+  maxProjects?: number;
 }

--- a/src/app/components/ui/profile/portfolio/ProjectImages.tsx
+++ b/src/app/components/ui/profile/portfolio/ProjectImages.tsx
@@ -6,9 +6,10 @@ import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConver
 interface ProjectImagesProps {
   projects: Project[];
   variant: 'default' | 'long';
+  maxProjects?: number;
 }
 
-const ProjectImages = ({ projects, variant }: ProjectImagesProps) => {
+const ProjectImages = ({ projects, variant, maxProjects }: ProjectImagesProps) => {
   const containerClass =
     variant === 'default'
       ? 'h-[5.75rem] flex gap-1 w-full overflow-hidden'
@@ -19,9 +20,14 @@ const ProjectImages = ({ projects, variant }: ProjectImagesProps) => {
       ? 'relative flex-1 h-[5.75rem]'
       : 'relative w-[9.375rem] h-[5.75rem] flex-shrink-0';
 
+  // maxProjects가 undefined면 무제한, number면 해당 개수만큼 제한
+  const displayProjects = maxProjects !== undefined 
+    ? projects.slice(0, maxProjects)
+    : projects;
+
   return (
     <div className={containerClass}>
-      {(variant === 'default' ? projects.slice(0, 3) : projects).map(
+      {displayProjects.map(
         (project, index) => (
           <div className={imageClass} key={index}>
             <Image

--- a/src/services/team/getTeam.server.ts
+++ b/src/services/team/getTeam.server.ts
@@ -24,6 +24,12 @@ export const getAllTeams = async (): Promise<TeamData[] | null> => {
           profile_id,
           profile_image
         )
+      ),
+      projects!projects_owner_fkey (
+        project_id,
+        project_name,
+        project_thumbnail,
+        description
       )
     `,
     )
@@ -99,6 +105,12 @@ export const getTeamsByProfileName = async (
           profile_id,
           profile_image
         )
+      ),
+      projects!projects_owner_fkey (
+        project_id,
+        project_name,
+        project_thumbnail,
+        description
       )
     `,
     )

--- a/src/utils/transformTeamToPortfolioCard.ts
+++ b/src/utils/transformTeamToPortfolioCard.ts
@@ -1,5 +1,6 @@
 import {
   Profile,
+  Project,
   PortfolioCardProps,
 } from '@/app/components/card/portfolio/types';
 import { TeamData } from '@/app/(box-layout)/team/types';
@@ -26,14 +27,14 @@ export function transformTeamToPortfolioCard(
       : '',
   };
 
-  // 팀원들을 프로젝트 형태로 변환 (팀원 프로필 이미지를 표시하기 위해)
-  const projects =
-    team.team_member?.map((member, index) => ({
-      title: `Member ${index + 1}`,
-      description: '',
+  // 팀의 모든 프로젝트를 전달 (개수 제한은 PortfolioCard에서 처리)
+  const projects: Project[] =
+    team.projects?.map((project) => ({
+      title: project.project_name,
+      description: project.description || '',
       logo: '',
-      projectImage: member.profile.profile_image
-        ? convertFromDatabaseImageURL(member.profile.profile_image)
+      projectImage: project.project_thumbnail
+        ? convertFromDatabaseImageURL(project.project_thumbnail)
         : '',
     })) ?? [];
 


### PR DESCRIPTION
## 💡 개요

포트폴리오 카드 컴포넌트들이 개인 프로필의 경우 `profile_name` 대신 실제 학생 이름(`student_name`)을 표시하도록 개선했습니다. 이를 통해 사용자가 포트폴리오를 탐색할 때 더 직관적으로 학생을 식별할 수 있게 되었습니다.

기존에는 모든 포트폴리오 카드에서 `profile_name`(프로필 URL에 사용되는 이름)을 표시했으나, 이제 개인 포트폴리오는 실제 학생 이름을 표시하고 팀 포트폴리오는 팀 이름을 표시합니다.

MaxProjects로 PortfolioCard에 들어갈 수 있는 최대 프로젝트를 제어할 수 있게 하였습니다.

## 📃 작업내용

### 주요 구현 사항

1. **타입 정의 확장**
   - `PortfolioCardProps`에 `studentName` 옵션 필드 추가
   - `BusinessCardData`에 `studentName` 옵션 필드 추가

2. **컴포넌트 로직 개선**
   - `PortfolioCard`: studentName이 있으면 이를 우선 표시, 없으면 profile.name 사용
   - `BusinessCard`: 동일한 로직 적용
   - `ProfileImage`와 `ProfileInfo` 컴포넌트에 올바른 이름 전달

3. **데이터 전달 체인 구축**
   - SearchTab → PortfolioCard에 studentName 전달
   - BusinessCardHolder → PortfolioCard에 studentName 전달
   - AutoSlidingBusinessCard의 변환 함수에서 studentName 설정

4. **API 버그 수정**
   - `getPaginatedPortfolioData.server.ts`에서 student 데이터 alias 누락 수정
   - `profile_owner_fkey1` → `student!profile_owner_fkey1`로 변경하여 student 데이터 올바르게 접근

### 시스템 흐름도

```mermaid
graph TB
    A[Supabase Query] --> B{student alias 설정}
    B --> C[student!profile_owner_fkey1]
    C --> D[PortfolioData with student.name]
    
    D --> E[SearchTab]
    D --> F[BusinessCardHolder]
    D --> G[AutoSlidingBusinessCard]
    
    E --> H[PortfolioCard]
    F --> H
    G --> I[BusinessCard]
    
    H --> J{studentName 존재?}
    I --> K{studentName 존재?}
    
    J -->|Yes| L[student.name 표시]
    J -->|No| M[profile.name 표시]
    
    K -->|Yes| N[student.name 표시]
    K -->|No| O[profile.name 표시]
```

### 핵심 로직

#### 1. PortfolioCard 표시 로직
```typescript
const PortfolioCard = ({ profile, projects, src, studentName }) => {
  // 팀이 아닌 경우 studentName을 사용, 없으면 profile.name 사용
  const displayName = studentName || profile.name;
  
  return (
    <ProfileImage name={displayName} />
    <ProfileInfo profile={{ ...profile, name: displayName }} />
  );
};
```

#### 2. 데이터 전달
```typescript
// SearchTab.tsx
<PortfolioCard
  profile={data.profile}
  projects={data.projects}
  studentName={data.student?.name}  // 학생 실명 전달
/>

// AutoSlidingBusinessCard.tsx
const convertPortfolioToBusinessCard = (portfolio) => ({
  name: portfolio.profile.name,
  studentName: portfolio.student?.name,  // 학생 실명 설정
  ...
});
```

## 🔀 변경사항

### 수정된 파일

#### 타입 정의
- `src/app/components/card/portfolio/types.d.ts`: PortfolioCardProps에 studentName 필드 추가

#### 컴포넌트
- `src/app/components/card/portfolio/PortfolioCard.tsx`: studentName prop 받아서 displayName으로 사용
- `src/app/(box-layout)/portfolio/SearchTab.tsx`: studentName 전달
- `src/app/components/card/home/BusinessCardHolder.tsx`: studentName 전달
- `src/app/components/card/home/BusinessCard.tsx`: studentName 필드 추가 및 사용
- `src/app/components/card/home/AutoSlidingBusinessCard.tsx`: 변환 함수에서 studentName 설정

#### API/서비스
- `src/services/portfolio/getPaginatedPortfolioData.server.ts`: **[버그 수정]** student alias 누락 수정

### 주요 변경 포인트

1. **타입 안전성**: TypeScript 인터페이스에 studentName 필드 명시적으로 추가
2. **일관성**: 모든 포트폴리오 카드 컴포넌트에서 동일한 로직 적용
3. **하위 호환성**: studentName이 없는 경우(팀 프로필) 기존 동작 유지
4. **버그 수정**: Supabase query에서 student 데이터를 올바르게 가져오도록 alias 수정

### 영향 범위

- ✅ 포트폴리오 검색 페이지 (SearchTab)
- ✅ 최근 본 포트폴리오 목록 (BusinessCardHolder)
- ✅ 홈 화면 슬라이딩 명함 (AutoSlidingBusinessCard)
- ✅ 팀 프로필은 기존대로 팀 이름 표시 (studentName이 없으므로)

### 개선 효과

- 👤 사용자가 포트폴리오 탐색 시 실제 학생 이름을 볼 수 있어 더 직관적
- 🔍 검색 결과에서 학생 식별이 용이
- 🎯 profile_name과 student_name의 역할 분리 명확화
- 🐛 API에서 student 데이터를 가져오지 못하던 버그 수정

## 📸 스크린샷
