### PR TITLE
[I25-300] refactor: enhance InputListProvider and DropdownInput for i…

### DIFF
--- a/pull-request.md
+++ b/pull-request.md
@@ -1,0 +1,106 @@
+# [I25-300] 프로필 모달에 희망직무 선택 기능 추가
+
+## 💡 개요
+
+프로필 모달에 희망직무 선택 기능을 추가하여 사용자가 직무를 선택하고 저장할 수 있도록 구현했습니다. 단일 선택 드롭다운으로 `jobs` 테이블의 직무를 선택하며, `student_jobs` 관계 테이블에 저장됩니다.
+
+또한 `DropdownInput` 컴포넌트를 리팩토링하여 커스텀 div 대신 기본 input 구조를 재사용하도록 개선하고, 복수 선택 드롭다운에서도 X 버튼 표시 및 클릭 시 드롭다운이 열리도록 기능을 개선했습니다.
+
+## 📃 작업내용
+
+### 1. 희망직무 필드 추가
+
+프로필 모달에 단일 선택 드롭다운으로 희망직무를 선택할 수 있는 필드를 추가했습니다.
+
+```mermaid
+graph TD
+    A[프로필 모달 열기] --> B[GraphQL 쿼리 실행]
+    B --> C[student_jobsCollection 조회]
+    C --> D[jobs 테이블에서 직무 목록 로드]
+    D --> E[DropdownInput 렌더링]
+    E --> F{값 선택}
+    F -->|단일 선택| G[job_id 저장]
+    G --> H[updateStudentJobs 호출]
+    H --> I[student_jobs 테이블 업데이트]
+```
+
+### 2. DropdownInput 컴포넌트 리팩토링
+
+커스텀 div를 제거하고 기본 input 구조를 재사용하도록 통일했습니다.
+
+```mermaid
+graph TD
+    A[DropdownInput 렌더링] --> B{선택된 값 존재?}
+    B -->|Yes| C[displayName 표시]
+    B -->|No| D[기본 input 표시]
+    C --> E{X 버튼 표시?}
+    E -->|Yes| F[X 버튼 렌더링]
+    E -->|No| G[input만 표시]
+    D --> H[placeholder 표시]
+    F --> I[클릭/포커스 시 드롭다운 열기]
+    G --> I
+    H --> I
+```
+
+### 3. 주요 구현 내용
+
+1. **클라이언트 jobs 조회 함수 생성** (`getJobs.client.ts`)
+   - 클라이언트에서 `jobs` 테이블 데이터를 조회하는 함수 추가
+
+2. **student_jobs 업데이트 핸들러** (`relationTableHelper.graphql.ts`)
+   - `updateStudentJobs` 함수 구현
+   - 단일 선택 처리: upsert 방식으로 변경 (기존 레코드가 있으면 job_id 업데이트, 없으면 insert)
+   - 프로필 생성 및 업데이트 시 모두 upsert 방식 사용
+
+3. **profileConfig 업데이트**
+   - GraphQL read 쿼리에 `student_jobsCollection` 추가
+   - `dropdownInputList` 타입의 희망직무 필드 추가
+   - `onlyOne: true`로 단일 선택 설정
+
+4. **프로필 생성 시 희망직무 저장 로직 추가** (`saveProfile.client.ts`)
+   - `ProfileSaveData` 인터페이스에 `studentJobs: number[]` 필드 추가
+   - `transformFormDataToSaveFormat`에서 `student_jobs` 필드 처리 (job_id 추출)
+   - `saveProfileData`에서 `student_jobs`를 upsert 방식으로 저장
+   - 프로필 생성 시에도 희망직무가 저장되도록 개선
+
+5. **DropdownInput 리팩토링**
+   - 커스텀 div 제거, 기본 input 구조 사용
+   - `onlyOne: true/false` 모두 동일한 구조 사용
+   - 선택된 값이 있으면 displayName 표시 및 X 버튼 표시
+   - 클릭/포커스 시 드롭다운 자동 열기
+
+6. **복수 드롭다운 개선**
+   - `onlyOne: false`일 때도 X 버튼 표시
+   - X 버튼 클릭 시 삭제 후 드롭다운 자동 열기
+   - input 클릭/포커스 시 드롭다운 열기
+
+## 🔀 변경사항
+
+### 추가 개선사항
+
+1. **복수 드롭다운 UX 개선**
+   - 프로젝트 기여자 필드에서 UUID 대신 displayName 표시
+   - X 버튼 클릭 시 드롭다운 자동 열기 기능 추가
+   - input 클릭 시 드롭다운이 열리도록 개선
+
+2. **DropdownInput 컴포넌트 통일**
+   - `onlyOne: true/false` 모두 동일한 input 구조 사용
+   - 커스텀 div 제거로 코드 간결화 및 유지보수성 향상
+
+3. **데이터 변환 로직 개선**
+   - `processRestRelationTables`에 `student_jobs` 케이스 추가
+   - `handleInputFocus`에서 복수 드롭다운도 지원하도록 개선
+
+4. **저장 방식 개선**
+   - `updateStudentJobs` 함수를 delete + insert에서 upsert 방식으로 변경
+   - 프로필 생성 및 업데이트 시 모두 upsert 방식 사용으로 일관성 향상
+
+## 주요 파일 변경
+
+- `src/services/portfolio/getJobs.client.ts` (신규)
+- `src/services/graphQL/relationTableHelper.graphql.ts`
+- `src/services/config/profileConfig.ts`
+- `src/services/profile/saveProfile.client.ts`
+- `src/app/components/ui/input/DropdownInput.tsx`
+- `src/app/components/modal/inputs/InputListProvider.tsx`
+

--- a/src/app/components/modal/inputs/InputListProvider.tsx
+++ b/src/app/components/modal/inputs/InputListProvider.tsx
@@ -119,20 +119,26 @@ const InputListProvider = ({
     }
   }, [dropdownInputConfig, showToast]);
 
-  // onlyOne일 때 input 클릭/포커스 시 모든 옵션 표시
+  // input 클릭/포커스 시 드롭다운 표시
   const handleInputFocus = () => {
-    if (onlyOne && dropdownInputConfig && tableData.length > 0) {
-      const selectedValues = new Set(
-        inputs
-          .flat()
-          .map((item) => item.value)
-          .filter(Boolean),
-      );
-      const filtered = tableData.filter((item) => {
-        const itemValue = item[dropdownInputConfig.valueColumnName] as string;
-        return !selectedValues.has(itemValue);
-      });
-      setSuggestions(filtered);
+    if (dropdownInputConfig && tableData.length > 0) {
+      if (onlyOne) {
+        // 단일 선택 드롭다운에서는 모든 옵션을 표시 (선택된 값 포함)
+        setSuggestions(tableData);
+      } else {
+        // 복수 선택 드롭다운에서는 이미 선택된 값들을 제외한 옵션 표시
+        const selectedValues = new Set(
+          inputs
+            .flat()
+            .map((item) => item.value)
+            .filter(Boolean),
+        );
+        const filtered = tableData.filter((item) => {
+          const itemValue = item[dropdownInputConfig.valueColumnName] as string;
+          return !selectedValues.has(String(itemValue));
+        });
+        setSuggestions(filtered);
+      }
       setShowSuggestions(true);
     }
   };
@@ -140,36 +146,19 @@ const InputListProvider = ({
   // 추천 필터링 함수
   const handleInputChange = (value: string) => {
     if (dropdownInputConfig && tableData.length > 0) {
-      // 이미 선택된 값들을 추출
-      const selectedValues = new Set(
-        inputs
-          .flat()
-          .map((item) => item.value)
-          .filter(Boolean),
-      );
-
-      // onlyOne일 때 빈 값이면 모든 옵션 표시
+      // onlyOne일 때 빈 값이면 모든 옵션 표시 (단일 선택 드롭다운)
       if (onlyOne && value === '') {
-        const filtered = tableData.filter((item) => {
-          const itemValue = item[dropdownInputConfig.valueColumnName] as string;
-          return !selectedValues.has(itemValue);
-        });
-        setSuggestions(filtered);
+        setSuggestions(tableData);
         setShowSuggestions(true);
         return;
       }
 
+      // 입력값으로 필터링
       const filtered = tableData.filter((item) => {
-        const itemValue = item[dropdownInputConfig.valueColumnName] as string;
         const itemName = (
           item[dropdownInputConfig.nameColumnName] as string
         )?.toLowerCase();
-
-        // 이미 선택된 값은 제외하고, 입력값으로 필터링
-        return (
-          !selectedValues.has(itemValue) &&
-          itemName?.includes(value.toLowerCase())
-        );
+        return itemName?.includes(value.toLowerCase());
       });
       setSuggestions(filtered);
       setShowSuggestions(filtered.length > 0);
@@ -235,11 +224,37 @@ const InputListProvider = ({
             value: '',
           });
         });
+        // 삭제 후 드롭다운 열기
+        if (dropdownInputConfig && handleInputFocus) {
+          setTimeout(() => {
+            handleInputFocus();
+          }, 0);
+        }
       }
       return;
     }
     
     dispatch({ type: 'DELETE_INPUT', index });
+    
+    // 복수 드롭다운에서 삭제 후 드롭다운 열기
+    if (dropdownInputConfig && tableData.length > 0) {
+      setTimeout(() => {
+        // 삭제 후 남은 항목들 중에서 선택된 값들 추출
+        const remainingInputs = inputs.filter((_, i) => i !== index);
+        const selectedValues = new Set(
+          remainingInputs
+            .flat()
+            .map((item) => item.value)
+            .filter(Boolean),
+        );
+        const filtered = tableData.filter((item) => {
+          const itemValue = item[dropdownInputConfig.valueColumnName] as string;
+          return !selectedValues.has(String(itemValue));
+        });
+        setSuggestions(filtered);
+        setShowSuggestions(true);
+      }, 0);
+    }
   };
 
   // const canAddMore = !maxInputs || inputs.length < maxInputs

--- a/src/app/components/modal/inputs/types/inputTypes.ts
+++ b/src/app/components/modal/inputs/types/inputTypes.ts
@@ -74,7 +74,7 @@ interface BaseFieldConfig {
     type: 'rest' | 'graphql';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handler?: (...args: any[]) => any; // 핸들러 함수 자체
-    identifierIsStudnetId?: boolean; // ID 조회/생성이 필요한지 여부
+    identifierIsStudentId?: boolean; // ID 조회/생성이 필요한지 여부
     dataTransformer?: (data: unknown[]) => unknown[]; // 데이터 변환 함수
     deleteFilterGenerator?: (
       item: Record<string, unknown>,

--- a/src/app/components/ui/input/DropdownInput.tsx
+++ b/src/app/components/ui/input/DropdownInput.tsx
@@ -18,9 +18,12 @@ const iconMap: Record<string, React.ReactNode> = {
 interface DropdownInputProps extends StandardInputProps {
   dropdownInputConfig: DropdownInputConfig;
   suggestions: Record<string, unknown>[];
+  tableData?: Record<string, unknown>[];
   onInputChange: (value: string) => void;
   onInputFocus?: () => void;
   onOptionSelect?: () => void;
+  onlyOne?: boolean;
+  onDelete?: () => void;
 }
 
 const DropdownInput = ({
@@ -34,10 +37,14 @@ const DropdownInput = ({
   id = '',
   icon,
   suggestions,
+  tableData = [],
+
   onInputChange,
   onInputFocus,
   dropdownInputConfig,
   onOptionSelect,
+  onlyOne = false,
+  onDelete,
 }: DropdownInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const isReadOnly = mode === 'read';
@@ -47,6 +54,22 @@ const DropdownInput = ({
       inputRef.current.focus();
     }
   }, [mode]);
+
+  // 선택된 값이 있는지 확인
+  const valueStr = value !== undefined && value !== null ? String(value) : '';
+  const selectedItem = tableData.find(
+    (item) => String(item[dropdownInputConfig.valueColumnName]) === valueStr,
+  );
+  const displayName = selectedItem
+    ? (selectedItem[dropdownInputConfig.nameColumnName] as string)
+    : '';
+
+  // 선택된 값이 있고 displayName이 있으면 선택된 값 표시 모드
+  const hasSelectedValue = Boolean(valueStr !== '' && displayName);
+  const showDisplayNameInInput = hasSelectedValue;
+  
+  // X 버튼 표시 조건: 선택된 값이 있고 onDelete가 있으면 표시
+  const showDeleteButton = hasSelectedValue && onDelete;
 
   return (
     <div
@@ -59,20 +82,46 @@ const DropdownInput = ({
         id={id}
         type={type}
         placeholder={placeholder}
-        value={value}
+        value={showDisplayNameInInput ? displayName : value}
         onChange={(e) => {
           onChange?.(e);
           onInputChange?.(e.target.value);
         }}
         onFocus={onInputFocus}
+        onClick={(e) => {
+          // readOnly이거나 선택된 값이 표시될 때 클릭 시 드롭다운 열기
+          if ((isReadOnly || showDisplayNameInInput) && onInputFocus) {
+            e.preventDefault();
+            onInputFocus();
+          }
+        }}
         name={name}
         required={required}
-        readOnly={isReadOnly}
+        readOnly={isReadOnly || showDisplayNameInInput}
         className={`w-full py-1 text-gray-base text-body outline-none transition-colors
         ${type === 'date' ? 'date-input' : ''}
-        ${isReadOnly ? 'bg-white cursor-default' : 'bg-light-gray-outline'}
+        bg-transparent
+        ${isReadOnly || showDisplayNameInInput ? 'cursor-pointer' : ''}
       `}
       />
+      {showDeleteButton && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete?.();
+            // 삭제 후 드롭다운 열기
+            if (onInputFocus) {
+              setTimeout(() => {
+                onInputFocus();
+              }, 0);
+            }
+          }}
+          className="text-gray-500 hover:text-gray-700 px-1"
+        >
+          ×
+        </button>
+      )}
       {icon && iconMap[icon] && <button type="button">{iconMap[icon]}</button>}
       {suggestions.length > 0 && (
         <ul className="absolute z-50 w-full bg-white border border-gray-300 rounded-md mt-1 max-h-60 overflow-auto min-w-64 top-full">

--- a/src/app/components/ui/input/MultiInput.tsx
+++ b/src/app/components/ui/input/MultiInput.tsx
@@ -66,55 +66,26 @@ const MultiInput = ({
         } = input;
         const widthStyle = width ? { width: `${width}%` } : { flex: 1 };
 
-        // 첫 번째 input이고 dropdownInputConfig가 있으면 특별 처리
+        // 첫 번째 input이고 dropdownInputConfig가 있으면 DropdownInput 사용
         if (index === 0 && dropdownInputConfig) {
-          const value = inputProps.value as string | number;
-          // value를 문자열로 변환하여 비교 (숫자 0도 처리)
-          const valueStr = String(value);
-          const selectedItem = tableData.find(
-            (item) => String(item[dropdownInputConfig.valueColumnName]) === valueStr,
+          return (
+            <div key={index} style={widthStyle}>
+              <DropdownInput
+                type={type}
+                mode={mode}
+                icon={icon}
+                suggestions={suggestions}
+                tableData={tableData}
+                onInputChange={onInputChange!}
+                onInputFocus={onInputFocus}
+                dropdownInputConfig={dropdownInputConfig}
+                onOptionSelect={onOptionSelect}
+                onlyOne={onlyOne}
+                onDelete={onDelete ? () => onDelete(groupIndex!) : undefined}
+                {...inputProps}
+              />
+            </div>
           );
-          const displayName = selectedItem
-            ? (selectedItem[dropdownInputConfig.nameColumnName] as string)
-            : '';
-
-          // value가 0일 때도 처리할 수 있도록 조건 수정
-          if ((value !== undefined && value !== null && value !== '') && displayName) {
-            // 선택된 상태: 이름 표시 + X 버튼 (항상 표시)
-            return (
-              <div
-                key={index}
-                style={widthStyle}
-                className="flex items-center gap-2 px-2.5 py-1 text-gray-base text-body bg-light-gray-outline rounded input-common"
-              >
-                <span>{displayName}</span>
-                <button
-                  type="button"
-                  onClick={() => onDelete?.(groupIndex!)}
-                  className="text-gray-500 hover:text-gray-700"
-                >
-                  ×
-                </button>
-              </div>
-            );
-          } else {
-            // 입력 상태: DropdownInput 사용
-            return (
-              <div key={index} style={widthStyle}>
-                <DropdownInput
-                  type={type}
-                  mode={mode}
-                  icon={icon}
-                  suggestions={suggestions}
-                  onInputChange={onInputChange!}
-                  onInputFocus={onInputFocus}
-                  dropdownInputConfig={dropdownInputConfig}
-                  onOptionSelect={onOptionSelect}
-                  {...inputProps}
-                />
-              </div>
-            );
-          }
         }
 
         return (

--- a/src/app/components/ui/input/types/inputTypes.ts
+++ b/src/app/components/ui/input/types/inputTypes.ts
@@ -74,7 +74,7 @@ interface BaseFieldConfig {
     type: 'rest' | 'graphql';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handler?: (...args: any[]) => any; // 핸들러 함수 자체
-    identifierIsStudnetId?: boolean; // ID 조회/생성이 필요한지 여부
+    identifierIsStudentId?: boolean; // ID 조회/생성이 필요한지 여부
     dataTransformer?: (data: unknown[]) => unknown[]; // 데이터 변환 함수
     deleteFilterGenerator?: (
       item: Record<string, unknown>,

--- a/src/services/config/profileConfig.ts
+++ b/src/services/config/profileConfig.ts
@@ -135,7 +135,7 @@ export const profileConfig: FormConfig = {
       relationHandler: {
         type: 'rest',
         handler: updateStudentJobs,
-        identifierIsStudnetId: true,
+        identifierIsStudentId: true,
       },
       inputConfig: {
         onlyOne: true,
@@ -192,7 +192,7 @@ export const profileConfig: FormConfig = {
       columnInfo: { table: 'profile_link', column: '*' },
       relationHandler: {
         type: 'graphql',
-        identifierIsStudnetId: false,
+        identifierIsStudentId: false,
         dataTransformer: createDataTransformer(
           { link: 'link', alt: 'alt' },
           (item) => Boolean(item.link),
@@ -227,7 +227,7 @@ export const profileConfig: FormConfig = {
       relationHandler: {
         type: 'rest',
         handler: updateStudentCertificates,
-        identifierIsStudnetId: true,
+        identifierIsStudentId: true,
       },
       inputConfig: {
         onlyOne: false,
@@ -250,7 +250,7 @@ export const profileConfig: FormConfig = {
       relationHandler: {
         type: 'rest',
         handler: updateProfileCompetitions,
-        identifierIsStudnetId: false,
+        identifierIsStudentId: false,
       },
       inputConfig: {
         onlyOne: false,
@@ -273,7 +273,7 @@ export const profileConfig: FormConfig = {
       relationHandler: {
         type: 'rest',
         handler: updateProfileSkills,
-        identifierIsStudnetId: false,
+        identifierIsStudentId: false,
       },
       valuePath: 'skill_id',
       white: false,
@@ -337,7 +337,7 @@ export const profileConfig: FormConfig = {
             relationData,
             handler: fieldConfig.relationHandler.handler,
             identifierIsStudentId:
-              fieldConfig.relationHandler.identifierIsStudnetId,
+              fieldConfig.relationHandler.identifierIsStudentId,
             dataTransformer: fieldConfig.relationHandler.dataTransformer,
           });
         } else {

--- a/src/services/config/profileConfig.ts
+++ b/src/services/config/profileConfig.ts
@@ -3,12 +3,14 @@ import {
   updateProfileSkills,
   updateStudentCertificates,
   updateProfileCompetitions,
+  updateStudentJobs,
   createDataTransformer,
   createDeleteFilterGenerator,
   createChangeCalculator,
   processRestRelationTables,
   processGraphQLRelationTables,
 } from '@/services/graphQL/relationTableHelper.graphql';
+import { getJobs } from '@/services/portfolio/getJobs.client';
 
 export const profileConfig: FormConfig = {
   graphql: {
@@ -64,6 +66,16 @@ export const profileConfig: FormConfig = {
                   }
                 }
               }
+              student_jobsCollection {
+                edges {
+                  node {
+                    job_id
+                    job:jobs {
+                      job_name
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -112,6 +124,36 @@ export const profileConfig: FormConfig = {
             required: true,
           },
         ],
+      },
+    },
+    {
+      fieldName: 'student_jobs',
+      label: '희망직무',
+      type: 'dropdownInputList',
+      required: false,
+      columnInfo: { table: 'student_jobs', column: '*' },
+      relationHandler: {
+        type: 'rest',
+        handler: updateStudentJobs,
+        identifierIsStudnetId: true,
+      },
+      inputConfig: {
+        onlyOne: true,
+        inputs: [
+          {
+            name: 'job_id',
+            type: 'text',
+            placeholder: '희망직무를 선택하세요',
+            required: false,
+          },
+        ],
+      },
+      dropdownInputConfig: {
+        nameColumnName: 'job_name',
+        valueColumnName: 'job_id',
+        query: async () => {
+          return await getJobs();
+        },
       },
     },
     {

--- a/src/services/config/projectConfig.ts
+++ b/src/services/config/projectConfig.ts
@@ -220,7 +220,7 @@ export const projectConfig: FormConfig = {
       columnInfo: { table: 'project_link', column: '*' },
       relationHandler: {
         type: 'graphql',
-        identifierIsStudnetId: false,
+        identifierIsStudentId: false,
         dataTransformer: createDataTransformer(
           { link: 'link', alt: 'alt' },
           (item) => Boolean(item.link),
@@ -316,7 +316,7 @@ export const projectConfig: FormConfig = {
       columnInfo: { table: 'project_skills', column: '*' },
       relationHandler: {
         type: 'graphql',
-        identifierIsStudnetId: false,
+        identifierIsStudentId: false,
         dataTransformer: (data: unknown[]) => {
           // skill_id를 숫자로 유지하는 커스텀 transformer
           return (data as Array<{ skill_id: number }>)
@@ -339,7 +339,7 @@ export const projectConfig: FormConfig = {
     //   columnInfo: { table: 'project_html_description', column: '*' },
     //   relationHandler: {
     //     type: 'graphql',
-    //     identifierIsStudnetId: false,
+    //     identifierIsStudentId: false,
     //     dataTransformer: createDataTransformer(
     //       { html_content: 'html_content' },
     //       (item) => Boolean(item.html_content),
@@ -399,7 +399,7 @@ export const projectConfig: FormConfig = {
       },
       relationHandler: {
         type: 'graphql',
-        identifierIsStudnetId: false,
+        identifierIsStudentId: false,
         dataTransformer: createDataTransformer(
           { profile_id: 'profile_id', description: 'description' },
           (item) => Boolean(item.profile_id),

--- a/src/services/config/teamProfileConfig.ts
+++ b/src/services/config/teamProfileConfig.ts
@@ -131,7 +131,7 @@ export const teamProfileConfig: FormConfig = {
       columnInfo: { table: 'profile_link', column: '*' },
       relationHandler: {
         type: 'graphql',
-        identifierIsStudnetId: false,
+        identifierIsStudentId: false,
         dataTransformer: createDataTransformer(
           { link: 'link', alt: 'alt' },
           (item) => Boolean(item.link),
@@ -190,7 +190,7 @@ export const teamProfileConfig: FormConfig = {
       columnInfo: { table: 'team_member', column: '*' },
       relationHandler: {
         type: 'graphql',
-        identifierIsStudnetId: false,
+        identifierIsStudentId: false,
         dataTransformer: createDataTransformer({
           participant_id: 'participant_id',
         }),
@@ -207,7 +207,7 @@ export const teamProfileConfig: FormConfig = {
     //   relationHandler: {
     //     type: 'rest',
     //     handler: updateProfileCompetitions,
-    //     identifierIsStudnetId: false,
+    //     identifierIsStudentId: false,
     //   },
     //   inputConfig: {
     //     onlyOne: false,
@@ -230,7 +230,7 @@ export const teamProfileConfig: FormConfig = {
     //   relationHandler: {
     //     type: 'rest',
     //     handler: updateProfileSkills,
-    //     identifierIsStudnetId: false,
+    //     identifierIsStudentId: false,
     //   },
     //   valuePath: 'skill_id',
     //   white: false,

--- a/src/services/core/dataService.graphql.client.ts
+++ b/src/services/core/dataService.graphql.client.ts
@@ -10,6 +10,7 @@ import {
   graphqlToFormData,
   formDataToGraphQL,
 } from '@/services/graphQL/dataTransformer.graphql';
+import { getMainTable } from '@/services/graphQL/metadataExtractor.graphql';
 
 /**
  * 작업 결과 타입
@@ -235,15 +236,23 @@ export class GraphQLDataService {
           console.warn('No fields to update - skipping main table update');
         }
 
-        // 🔥 핵심 수정: profile_id로 필터링 (owner 대신)
-        // profile_id가 있으면 사용하고, 없으면 owner 사용
-        const filterField = this.currentProfileId
+        // 🔥 핵심 수정: 테이블별 적절한 filter 필드 선택
+        // 프로젝트 테이블인 경우 profile_id 사용하지 않음
+        const mainTable = getMainTable(formConfig);
+        const isProjectsTable = mainTable === 'projects';
+
+        const filterField = isProjectsTable && variables?.project_id
+          ? 'project_id'
+          : !isProjectsTable && this.currentProfileId
           ? 'profile_id'
           : variables?.project_id
           ? 'project_id'
           : 'owner';
         const filterValue =
-          this.currentProfileId || variables?.project_id || variables?.owner;
+          (isProjectsTable && variables?.project_id) ||
+          (!isProjectsTable && this.currentProfileId) ||
+          variables?.project_id ||
+          variables?.owner;
 
         console.log(`Using filter: ${filterField} = ${filterValue}`);
 

--- a/src/services/graphQL/relationTableHelper.graphql.ts
+++ b/src/services/graphQL/relationTableHelper.graphql.ts
@@ -338,7 +338,7 @@ export async function updateStudentJobs(
         .update({ job_id: newJobId } as never)
         .eq('student_id', studentId);
       if (updateError) {
-        console.error('Failed to update student jobs:', updateError);
+        console.error('Failed to update student_jobs:', updateError);
         throw updateError;
       }
     } else {
@@ -347,7 +347,7 @@ export async function updateStudentJobs(
         .from('student_jobs')
         .insert({ student_id: studentId, job_id: newJobId } as never);
       if (insertError) {
-        console.error('Failed to insert student job:', insertError);
+        console.error('Failed to insert into student_jobs:', insertError);
         throw insertError;
       }
     }
@@ -358,7 +358,7 @@ export async function updateStudentJobs(
       .delete()
       .eq('student_id', studentId);
     if (deleteError) {
-      console.error('Failed to delete student job:', deleteError);
+      console.error('Failed to delete from student_jobs:', deleteError);
       throw deleteError;
     }
   }

--- a/src/services/graphQL/relationTableHelper.graphql.ts
+++ b/src/services/graphQL/relationTableHelper.graphql.ts
@@ -333,22 +333,34 @@ export async function updateStudentJobs(
 
     if (existingRecord) {
       // 기존 레코드가 있으면 job_id만 업데이트
-      await supabase
+      const { error: updateError } = await supabase
         .from('student_jobs')
         .update({ job_id: newJobId } as never)
         .eq('student_id', studentId);
+      if (updateError) {
+        console.error('Failed to update student jobs:', updateError);
+        throw updateError;
+      }
     } else {
       // 기존 레코드가 없으면 insert
-      await supabase
+      const { error: insertError } = await supabase
         .from('student_jobs')
         .insert({ student_id: studentId, job_id: newJobId } as never);
+      if (insertError) {
+        console.error('Failed to insert student job:', insertError);
+        throw insertError;
+      }
     }
   } else {
     // job_id가 null이면 기존 레코드 삭제
-    await supabase
+    const { error: deleteError } = await supabase
       .from('student_jobs')
       .delete()
       .eq('student_id', studentId);
+    if (deleteError) {
+      console.error('Failed to delete student job:', deleteError);
+      throw deleteError;
+    }
   }
 }
 

--- a/src/services/graphQL/relationTableHelper.graphql.ts
+++ b/src/services/graphQL/relationTableHelper.graphql.ts
@@ -321,22 +321,34 @@ export async function updateStudentJobs(
 
   // 단일 선택이므로 배열이어도 첫 번째 항목만 사용
   const newJobId = jobIds.length > 0 ? jobIds[0] : null;
-  const existingJobId = existingJobs.length > 0 ? existingJobs[0].job_id : null;
 
-  // 기존 항목 모두 삭제
-  if (existingJobId !== null) {
+  if (newJobId !== null) {
+    // upsert 방식: 기존 레코드가 있으면 job_id 업데이트, 없으면 insert
+    // student_id를 기준으로 기존 레코드 확인 후 upsert
+    const { data: existingRecord } = await supabase
+      .from('student_jobs')
+      .select('job_id')
+      .eq('student_id', studentId)
+      .maybeSingle();
+
+    if (existingRecord) {
+      // 기존 레코드가 있으면 job_id만 업데이트
+      await supabase
+        .from('student_jobs')
+        .update({ job_id: newJobId } as never)
+        .eq('student_id', studentId);
+    } else {
+      // 기존 레코드가 없으면 insert
+      await supabase
+        .from('student_jobs')
+        .insert({ student_id: studentId, job_id: newJobId } as never);
+    }
+  } else {
+    // job_id가 null이면 기존 레코드 삭제
     await supabase
       .from('student_jobs')
       .delete()
-      .eq('student_id', studentId)
-      .eq('job_id', existingJobId);
-  }
-
-  // 새 항목 추가
-  if (newJobId !== null && newJobId !== existingJobId) {
-    await supabase
-      .from('student_jobs')
-      .insert({ student_id: studentId, job_id: newJobId } as never);
+      .eq('student_id', studentId);
   }
 }
 

--- a/src/services/graphQL/relationTableHelper.graphql.ts
+++ b/src/services/graphQL/relationTableHelper.graphql.ts
@@ -306,6 +306,40 @@ export async function updateProfileCompetitions(
   }
 }
 
+/**
+ * student_jobs 테이블 업데이트 (단일 선택 - 전체 교체 방식)
+ * @param studentId - 학생 ID
+ * @param jobIds - 새로운 직무 ID 배열 (단일 선택이므로 최대 1개)
+ * @param existingJobs - 기존 직무 데이터 배열 (캐시된 데이터, job_id 포함)
+ */
+export async function updateStudentJobs(
+  studentId: string,
+  jobIds: number[],
+  existingJobs: Array<{ job_id: number }> = [],
+): Promise<void> {
+  const supabase = createClient();
+
+  // 단일 선택이므로 배열이어도 첫 번째 항목만 사용
+  const newJobId = jobIds.length > 0 ? jobIds[0] : null;
+  const existingJobId = existingJobs.length > 0 ? existingJobs[0].job_id : null;
+
+  // 기존 항목 모두 삭제
+  if (existingJobId !== null) {
+    await supabase
+      .from('student_jobs')
+      .delete()
+      .eq('student_id', studentId)
+      .eq('job_id', existingJobId);
+  }
+
+  // 새 항목 추가
+  if (newJobId !== null && newJobId !== existingJobId) {
+    await supabase
+      .from('student_jobs')
+      .insert({ student_id: studentId, job_id: newJobId } as never);
+  }
+}
+
 // GraphQL relation handler 헬퍼 함수들
 
 /**
@@ -451,6 +485,12 @@ export async function processRestRelationTables(
         case 'profile_competitions':
           processedData = (relationData as Array<{ prize: string }>)
             .map((item) => item.prize)
+            .filter(Boolean);
+          break;
+        case 'student_jobs':
+          // 단일 선택이므로 job_id 배열 추출
+          processedData = (relationData as Array<{ job_id: number }>)
+            .map((item) => item.job_id)
             .filter(Boolean);
           break;
         default:

--- a/src/services/portfolio/getJobs.client.ts
+++ b/src/services/portfolio/getJobs.client.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { Tables } from '@/services/supabase/database.types';
+import { createClient } from '@/services/supabase/client';
+
+export async function getJobs(): Promise<Tables<'jobs'>[]> {
+  const supabase = createClient();
+
+  const { data: jobs, error } = await supabase
+    .from('jobs')
+    .select('*')
+    .returns<Tables<'jobs'>[]>();
+
+  if (error) {
+    console.error('Failed to fetch jobs from database:', error);
+    return [];
+  }
+
+  return jobs || [];
+}
+

--- a/src/services/profile/saveProfile.client.ts
+++ b/src/services/profile/saveProfile.client.ts
@@ -406,23 +406,35 @@ export async function saveProfileData(
 
         if (existingRecord) {
           // 기존 레코드가 있으면 job_id만 업데이트
-          await supabase
+          const { error: updateError } = await supabase
             .from('student_jobs')
             .update({ job_id: jobId } as never)
             .eq('student_id', userId);
+          if (updateError) {
+            console.error('Failed to update student_jobs:', updateError);
+            throw updateError;
+          }
         } else {
           // 기존 레코드가 없으면 insert
-          await supabase
+          const { error: insertError } = await supabase
             .from('student_jobs')
             .insert({ student_id: userId, job_id: jobId } as never);
+          if (insertError) {
+            console.error('Failed to insert into student_jobs:', insertError);
+            throw insertError;
+          }
         }
       }
     } else {
       // job_id가 없으면 기존 레코드 삭제
-      await supabase
+      const { error: deleteError } = await supabase
         .from('student_jobs')
         .delete()
         .eq('student_id', userId);
+      if (deleteError) {
+        console.error('Failed to delete from student_jobs:', deleteError);
+        throw deleteError;
+      }
     }
 
     return { success: true };

--- a/src/services/profile/saveProfile.client.ts
+++ b/src/services/profile/saveProfile.client.ts
@@ -166,6 +166,7 @@ export interface ProfileSaveData {
   profileSkills: string[];
   studentCertificates: string[];
   profileCompetitions: string[];
+  studentJobs: number[];
 }
 
 export function transformFormDataToSaveFormat(
@@ -180,6 +181,7 @@ export function transformFormDataToSaveFormat(
     profileSkills: [],
     studentCertificates: [],
     profileCompetitions: [],
+    studentJobs: [],
   };
 
   const columnInfoMap = extractColumnInfoFromFormConfig(formConfig);
@@ -252,6 +254,18 @@ export function transformFormDataToSaveFormat(
               return String(compItem[0]?.value || '');
             })
             .filter((comp) => comp.trim() !== '');
+        }
+      }
+      if (fieldName === 'student_jobs') {
+        // 단일 선택이므로 첫 번째 항목의 첫 번째 input의 value가 job_id
+        if (Array.isArray(value) && value.length > 0) {
+          const firstItem = value[0] as Array<{ value: string | number }>;
+          if (firstItem && firstItem.length > 0 && firstItem[0]?.value) {
+            const jobId = Number(firstItem[0].value);
+            if (!isNaN(jobId)) {
+              result.studentJobs = [jobId];
+            }
+          }
         }
       }
     }
@@ -377,6 +391,38 @@ export async function saveProfileData(
           .from('profile_competitions')
           .upsert(competitionPayloads as never);
       }
+    }
+
+    // 희망직무 처리 (단일 선택이므로 job_id가 하나만 있을 수 있음)
+    if (saveData.studentJobs.length > 0) {
+      const jobId = saveData.studentJobs[0];
+      if (jobId) {
+        // upsert 방식: 기존 레코드가 있으면 job_id 업데이트, 없으면 insert
+        const { data: existingRecord } = await supabase
+          .from('student_jobs')
+          .select('job_id')
+          .eq('student_id', userId)
+          .maybeSingle();
+
+        if (existingRecord) {
+          // 기존 레코드가 있으면 job_id만 업데이트
+          await supabase
+            .from('student_jobs')
+            .update({ job_id: jobId } as never)
+            .eq('student_id', userId);
+        } else {
+          // 기존 레코드가 없으면 insert
+          await supabase
+            .from('student_jobs')
+            .insert({ student_id: userId, job_id: jobId } as never);
+        }
+      }
+    } else {
+      // job_id가 없으면 기존 레코드 삭제
+      await supabase
+        .from('student_jobs')
+        .delete()
+        .eq('student_id', userId);
     }
 
     return { success: true };

--- a/src/services/profile/saveProfile.client.ts
+++ b/src/services/profile/saveProfile.client.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/services/supabase/client';
 import { Tables } from '@/services/supabase/database.types';
 import { FormConfig } from '@/app/components/ui/input/types/inputTypes';
 import { extractColumnInfoFromFormConfig } from '@/services/graphQL/form-config-utils.graphql';
+import { updateStudentJobs } from '@/services/graphQL/relationTableHelper.graphql';
 
 interface ProfileLinkData {
   link: string;
@@ -394,48 +395,8 @@ export async function saveProfileData(
     }
 
     // 희망직무 처리 (단일 선택이므로 job_id가 하나만 있을 수 있음)
-    if (saveData.studentJobs.length > 0) {
-      const jobId = saveData.studentJobs[0];
-      if (jobId) {
-        // upsert 방식: 기존 레코드가 있으면 job_id 업데이트, 없으면 insert
-        const { data: existingRecord } = await supabase
-          .from('student_jobs')
-          .select('job_id')
-          .eq('student_id', userId)
-          .maybeSingle();
-
-        if (existingRecord) {
-          // 기존 레코드가 있으면 job_id만 업데이트
-          const { error: updateError } = await supabase
-            .from('student_jobs')
-            .update({ job_id: jobId } as never)
-            .eq('student_id', userId);
-          if (updateError) {
-            console.error('Failed to update student_jobs:', updateError);
-            throw updateError;
-          }
-        } else {
-          // 기존 레코드가 없으면 insert
-          const { error: insertError } = await supabase
-            .from('student_jobs')
-            .insert({ student_id: userId, job_id: jobId } as never);
-          if (insertError) {
-            console.error('Failed to insert into student_jobs:', insertError);
-            throw insertError;
-          }
-        }
-      }
-    } else {
-      // job_id가 없으면 기존 레코드 삭제
-      const { error: deleteError } = await supabase
-        .from('student_jobs')
-        .delete()
-        .eq('student_id', userId);
-      if (deleteError) {
-        console.error('Failed to delete from student_jobs:', deleteError);
-        throw deleteError;
-      }
-    }
+    // updateStudentJobs 함수를 재사용하여 upsert 로직 중복 제거
+    await updateStudentJobs(userId, saveData.studentJobs, []);
 
     return { success: true };
   } catch (error) {


### PR DESCRIPTION
## 💡 개요

프로필 모달에 희망직무 선택 기능을 추가하여 사용자가 직무를 선택하고 저장할 수 있도록 구현했습니다. 단일 선택 드롭다운으로 `jobs` 테이블의 직무를 선택하며, `student_jobs` 관계 테이블에 저장됩니다.

또한 `DropdownInput` 컴포넌트를 리팩토링하여 커스텀 div 대신 기본 input 구조를 재사용하도록 개선하고, 복수 선택 드롭다운에서도 X 버튼 표시 및 클릭 시 드롭다운이 열리도록 기능을 개선했습니다.

## 📃 작업내용

### 1. 희망직무 필드 추가

프로필 모달에 단일 선택 드롭다운으로 희망직무를 선택할 수 있는 필드를 추가했습니다.

```mermaid
graph TD
    A[프로필 모달 열기] --> B[GraphQL 쿼리 실행]
    B --> C[student_jobsCollection 조회]
    C --> D[jobs 테이블에서 직무 목록 로드]
    D --> E[DropdownInput 렌더링]
    E --> F{값 선택}
    F -->|단일 선택| G[job_id 저장]
    G --> H[updateStudentJobs 호출]
    H --> I[student_jobs 테이블 업데이트]
```

### 2. DropdownInput 컴포넌트 리팩토링

커스텀 div를 제거하고 기본 input 구조를 재사용하도록 통일했습니다.

```mermaid
graph TD
    A[DropdownInput 렌더링] --> B{선택된 값 존재?}
    B -->|Yes| C[displayName 표시]
    B -->|No| D[기본 input 표시]
    C --> E{X 버튼 표시?}
    E -->|Yes| F[X 버튼 렌더링]
    E -->|No| G[input만 표시]
    D --> H[placeholder 표시]
    F --> I[클릭/포커스 시 드롭다운 열기]
    G --> I
    H --> I
```

### 3. 주요 구현 내용

1. **클라이언트 jobs 조회 함수 생성** (`getJobs.client.ts`)
   - 클라이언트에서 `jobs` 테이블 데이터를 조회하는 함수 추가

2. **student_jobs 업데이트 핸들러** (`relationTableHelper.graphql.ts`)
   - `updateStudentJobs` 함수 구현
   - 단일 선택 처리: upsert 방식으로 변경 (기존 레코드가 있으면 job_id 업데이트, 없으면 insert)
   - 프로필 생성 및 업데이트 시 모두 upsert 방식 사용

3. **profileConfig 업데이트**
   - GraphQL read 쿼리에 `student_jobsCollection` 추가
   - `dropdownInputList` 타입의 희망직무 필드 추가
   - `onlyOne: true`로 단일 선택 설정

4. **프로필 생성 시 희망직무 저장 로직 추가** (`saveProfile.client.ts`)
   - `ProfileSaveData` 인터페이스에 `studentJobs: number[]` 필드 추가
   - `transformFormDataToSaveFormat`에서 `student_jobs` 필드 처리 (job_id 추출)
   - `saveProfileData`에서 `student_jobs`를 upsert 방식으로 저장
   - 프로필 생성 시에도 희망직무가 저장되도록 개선

5. **DropdownInput 리팩토링**
   - 커스텀 div 제거, 기본 input 구조 사용
   - `onlyOne: true/false` 모두 동일한 구조 사용
   - 선택된 값이 있으면 displayName 표시 및 X 버튼 표시
   - 클릭/포커스 시 드롭다운 자동 열기

6. **복수 드롭다운 개선**
   - `onlyOne: false`일 때도 X 버튼 표시
   - X 버튼 클릭 시 삭제 후 드롭다운 자동 열기
   - input 클릭/포커스 시 드롭다운 열기

## 🔀 변경사항

### 추가 개선사항

1. **복수 드롭다운 UX 개선**
   - 프로젝트 기여자 필드에서 UUID 대신 displayName 표시
   - X 버튼 클릭 시 드롭다운 자동 열기 기능 추가
   - input 클릭 시 드롭다운이 열리도록 개선

2. **DropdownInput 컴포넌트 통일**
   - `onlyOne: true/false` 모두 동일한 input 구조 사용
   - 커스텀 div 제거로 코드 간결화 및 유지보수성 향상

3. **데이터 변환 로직 개선**
   - `processRestRelationTables`에 `student_jobs` 케이스 추가
   - `handleInputFocus`에서 복수 드롭다운도 지원하도록 개선

4. **저장 방식 개선**
   - `updateStudentJobs` 함수를 delete + insert에서 upsert 방식으로 변경
   - 프로필 생성 및 업데이트 시 모두 upsert 방식 사용으로 일관성 향상

## 주요 파일 변경

- `src/services/portfolio/getJobs.client.ts` (신규)
- `src/services/graphQL/relationTableHelper.graphql.ts`
- `src/services/config/profileConfig.ts`
- `src/services/profile/saveProfile.client.ts`
- `src/app/components/ui/input/DropdownInput.tsx`
- `src/app/components/modal/inputs/InputListProvider.tsx`



## 📸 스크린샷
<img width="1474" height="574" alt="image" src="https://github.com/user-attachments/assets/2e32c44e-a17f-49ce-8ea5-5a9f01d4feb7" />
