### PR TITLE
fix: 프로젝트 수정 시 소유자(owner) 변경 가능하도록 수정 (I25-302)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bsmhub",
       "version": "0.1.0",
       "dependencies": {
+        "@next/third-parties": "^16.0.3",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.76.1",
         "@tabler/icons-react": "^3.35.0",
@@ -1060,6 +1061,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.0.3.tgz",
+      "integrity": "sha512-QjTRQ4ydXguFkpMCUMl5oSslxmh8mAtmnzc9DEtLkZcGmAuQcZg2M3lswMn62sdID+F06crS3IQ58X3sjjBLVA==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7996,6 +8010,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tldts": {
       "version": "7.0.17",

--- a/src/services/core/dataService.graphql.client.ts
+++ b/src/services/core/dataService.graphql.client.ts
@@ -211,12 +211,15 @@ export class GraphQLDataService {
       let finalVariables: Record<string, unknown>;
 
       if (isUpdate) {
-        // Update: $set에는 실제 변경할 필드만 포함 (owner, is_team 제외)
-        // owner와 is_team은 filter에만 사용
+        // Update: $set에는 실제 변경할 필드만 포함
         const updateSet = { ...mainTableData };
 
         // 업데이트 시 변경하면 안 되는 필드 제거
-        delete updateSet.owner;
+        // profile의 owner(auth.uid)는 변경 불가하지만, project의 owner(profile_id)는 변경 가능
+        // project_id가 있으면 project 업데이트이므로 owner 유지
+        if (!variables?.project_id) {
+          delete updateSet.owner; // profile 업데이트인 경우에만 owner 제거
+        }
         delete updateSet.is_team;
         delete updateSet.project_id;
 


### PR DESCRIPTION
## 💡 개요
Jira 이슈 I25-302(소유자 프로필이 수정되지 않음) 해결을 위한 PR입니다.

## 📃 작업내용
- 프로젝트 수정 시 소유자(owner) 필드가 정상적으로 업데이트되도록 로직 개선
- package-lock.json 갱신

## 🔀 변경사항
- src/services/core/dataService.graphql.client.ts
- package-lock.json

## 📸 스크린샷
(해당 없음)

---
최근 커밋:
- 2466cc8 fix: 프로젝트 수정 시 소유자(owner) 변경 가능하도록 수정
- 47fed12 chore: update package-lock.json
