### PR TITLE
(i25 275) feat/전공동아리 기여자의 기수를 나눌 수 있게하기

### DIFF
--- a/docs/InputOfModal.md
+++ b/docs/InputOfModal.md
@@ -401,7 +401,7 @@ const { control, handleSubmit, formState: { errors } } = useForm({
   <Title>{title}</Title>
   
   {/* 각 필드 */}
-  <div className="w-full flex flex-col gap-2">
+  <div className="w-full flex flex-col gap-4">
     <LabelOfInputs label="..." required={...} />
     <InputListProvider ... />
     {errors && <span className="text-red-500 text-sm">...</span>}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bsmhub",
       "version": "0.1.0",
       "dependencies": {
+        "@next/third-parties": "^16.0.3",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.76.1",
         "@tabler/icons-react": "^3.35.0",
@@ -1060,6 +1061,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.0.3.tgz",
+      "integrity": "sha512-QjTRQ4ydXguFkpMCUMl5oSslxmh8mAtmnzc9DEtLkZcGmAuQcZg2M3lswMn62sdID+F06crS3IQ58X3sjjBLVA==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7996,6 +8010,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tldts": {
       "version": "7.0.17",

--- a/src/app/(box-layout)/team/Team.tsx
+++ b/src/app/(box-layout)/team/Team.tsx
@@ -25,7 +25,7 @@ const Team = async ({
 
   const projectsByYear = teamProjects.reduce(
     (acc, project) => {
-      const year = getFoundedYear(project.created_at);
+      const year = getFoundedYear(project.created_at ?? null);
       (acc[year] ??= []).push(project);
       return acc;
     },

--- a/src/app/(box-layout)/team/Team.tsx
+++ b/src/app/(box-layout)/team/Team.tsx
@@ -22,7 +22,7 @@ const Team = async ({
 
   const projectsByYear = teamProjects.reduce(
     (acc, project) => {
-      const year = project.created_at ? getFoundedYear(project.created_at) : -1;
+      const year = getFoundedYear(project.created_at);
       (acc[year] ??= []).push(project);
       return acc;
     },

--- a/src/app/(box-layout)/team/Team.tsx
+++ b/src/app/(box-layout)/team/Team.tsx
@@ -10,6 +10,9 @@ import Tabs from '@/app/components/layout/tabs/Tabs';
 import { Title } from '@/app/components/ui/text/text';
 import { getFoundedYear } from '@/utils/date';
 
+// 날짜 정보가 없는 프로젝트를 나타내는 상수
+const UNKNOWN_DATE_YEAR = -1;
+
 const Team = async ({
   teamName,
   path = 'home',
@@ -32,9 +35,9 @@ const Team = async ({
   const sortedYears = Object.keys(projectsByYear)
     .map(Number)
     .sort((a, b) => {
-      // "날짜 미상" (-1)은 항상 마지막에 표시
-      if (a === -1) return 1;
-      if (b === -1) return -1;
+      // "날짜 미상"은 항상 마지막에 표시
+      if (a === UNKNOWN_DATE_YEAR) return 1;
+      if (b === UNKNOWN_DATE_YEAR) return -1;
       return b - a; // 최신 년도부터 내림차순
     });
 
@@ -56,7 +59,7 @@ const Team = async ({
             <div className="w-full flex flex-col gap-8">
               {sortedYears.map((year) => (
                 <div key={year} className="w-full flex flex-col gap-4">
-                  <Title>{year === -1 ? '날짜 미상' : `${year}년`}</Title>
+                  <Title>{year === UNKNOWN_DATE_YEAR ? '날짜 미상' : `${year}년`}</Title>
                   <ProjectGrid
                     projects={projectsByYear[year]}
                     isTeamProject={true}

--- a/src/app/(box-layout)/team/Team.tsx
+++ b/src/app/(box-layout)/team/Team.tsx
@@ -54,7 +54,6 @@ const Team = async ({
                   <Title>{year}년</Title>
                   <ProjectGrid
                     projects={projectsByYear[year]}
-                    className=""
                     isTeamProject={true}
                   />
                 </div>

--- a/src/app/(box-layout)/team/Team.tsx
+++ b/src/app/(box-layout)/team/Team.tsx
@@ -31,7 +31,12 @@ const Team = async ({
 
   const sortedYears = Object.keys(projectsByYear)
     .map(Number)
-    .sort((a, b) => b - a);
+    .sort((a, b) => {
+      // "날짜 미상" (-1)은 항상 마지막에 표시
+      if (a === -1) return 1;
+      if (b === -1) return -1;
+      return b - a; // 최신 년도부터 내림차순
+    });
 
   return (
     <div className="w-full relative responsive-team">

--- a/src/app/(box-layout)/team/Team.tsx
+++ b/src/app/(box-layout)/team/Team.tsx
@@ -6,21 +6,61 @@ import TeamSidebar from '@/app/components/section/team/TeamSidebar';
 import ProfileIcon from '@/app/components/ui/profile/ProfileIcon';
 import ProjectGrid from '@/app/components/feature/project/components/ProjectGrid';
 import SidebarContentLayout from '@/app/components/layout/sidebar/SidebarContentLayout';
+import Tabs from '@/app/components/layout/tabs/Tabs';
+import { Title } from '@/app/components/ui/text/text';
+import { getFoundedYear } from '@/utils/date';
 
-const Team = async ({ teamName }: { teamName: string }) => {
+const Team = async ({
+  teamName,
+  path = 'home',
+}: {
+  teamName: string;
+  path?: 'home' | 'project';
+}) => {
   const teamDetail = (await getTeamData(teamName)) ?? notFound();
   const teamProjects = await getTeamProjects(teamName);
+
+  const projectsByYear = teamProjects.reduce(
+    (acc, project) => {
+      const year = project.created_at ? getFoundedYear(project.created_at) : 0;
+      (acc[year] ??= []).push(project);
+      return acc;
+    },
+    {} as Record<number, typeof teamProjects>,
+  );
+
+  const sortedYears = Object.keys(projectsByYear)
+    .map(Number)
+    .sort((a, b) => b - a);
 
   return (
     <div className="w-full relative responsive-team">
       <ProfileIcon image={teamDetail.profile_image} />
-      <SidebarContentLayout sidebar={<TeamSidebar teamDetail={teamDetail} projectCount={teamProjects.length} />}>
-        <section className="w-full">
-          <ProjectGrid
-            projects={teamProjects}
-            className="pl-[3rem] pt-[4.5rem] responsive-teamProjects"
-            isTeamProject={true}
-          />
+      <SidebarContentLayout
+        sidebar={
+          <TeamSidebar teamDetail={teamDetail} projectCount={teamProjects.length} />
+        }
+      >
+        <section className="w-full pl-[3rem] pt-[4.5rem] responsive-teamProjects">
+          <div className="mobile:hidden mb-6">
+            <Tabs tabs={['home', 'project']} />
+          </div>
+          {path === 'home' ? (
+            <ProjectGrid projects={teamProjects} className="" isTeamProject={true} />
+          ) : (
+            <div className="w-full flex flex-col gap-8">
+              {sortedYears.map((year) => (
+                <div key={year} className="w-full flex flex-col gap-4">
+                  <Title>{year}년</Title>
+                  <ProjectGrid
+                    projects={projectsByYear[year]}
+                    className=""
+                    isTeamProject={true}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
         </section>
       </SidebarContentLayout>
     </div>

--- a/src/app/(box-layout)/team/Team.tsx
+++ b/src/app/(box-layout)/team/Team.tsx
@@ -42,7 +42,7 @@ const Team = async ({
         }
       >
         <section className="w-full pl-[3rem] pt-[4.5rem] responsive-teamProjects">
-          <div className="mobile:hidden mb-6">
+          <div className="mb-6">
             <Tabs tabs={['home', 'project']} />
           </div>
           {path === 'home' ? (

--- a/src/app/(box-layout)/team/Team.tsx
+++ b/src/app/(box-layout)/team/Team.tsx
@@ -22,7 +22,7 @@ const Team = async ({
 
   const projectsByYear = teamProjects.reduce(
     (acc, project) => {
-      const year = project.created_at ? getFoundedYear(project.created_at) : 0;
+      const year = project.created_at ? getFoundedYear(project.created_at) : -1;
       (acc[year] ??= []).push(project);
       return acc;
     },
@@ -51,7 +51,7 @@ const Team = async ({
             <div className="w-full flex flex-col gap-8">
               {sortedYears.map((year) => (
                 <div key={year} className="w-full flex flex-col gap-4">
-                  <Title>{year}년</Title>
+                  <Title>{year === -1 ? '날짜 미상' : `${year}년`}</Title>
                   <ProjectGrid
                     projects={projectsByYear[year]}
                     isTeamProject={true}

--- a/src/app/(box-layout)/team/[teamName]/page.tsx
+++ b/src/app/(box-layout)/team/[teamName]/page.tsx
@@ -2,12 +2,15 @@ import Team from '../Team';
 
 interface TeamProps {
   params: Promise<{ teamName: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }
 
-const TeamPage = async ({ params }: TeamProps) => {
+const TeamPage = async ({ params, searchParams }: TeamProps) => {
   const teamName = (await params).teamName;
+  const searchParamsData = await searchParams;
+  const path = (searchParamsData.path as 'home' | 'project') ?? 'home';
 
-  return <Team teamName={decodeURIComponent(teamName)} />;
+  return <Team teamName={decodeURIComponent(teamName)} path={path} />;
 };
 
 export default TeamPage;

--- a/src/app/(box-layout)/team/types.d.ts
+++ b/src/app/(box-layout)/team/types.d.ts
@@ -15,6 +15,7 @@ export type TeamData = MergeDeep<
 >;
 
 export type TeamProjectType = PersonalProjectType & {
+  created_at?: string;
   profile: Pick<Tables<'profile'>, 'profile_name' | 'is_team'>;
   project_contributors: {
     profile: Pick<

--- a/src/app/components/card/portfolio/types.d.ts
+++ b/src/app/components/card/portfolio/types.d.ts
@@ -21,4 +21,5 @@ export interface PortfolioCardProps {
   isOfficial?: boolean;
   studentName?: string;
   maxProjects?: number;
+  createdAt?: string;
 }

--- a/src/app/components/feature/collect/CollectClient.tsx
+++ b/src/app/components/feature/collect/CollectClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, ChangeEvent, useMemo, useCallback } from 'react';
+import React, { useState, ChangeEvent, useMemo } from 'react';
 import Inputs from '@/app/components/ui/input/SingleInput';
 import InfinitePagination from '@/shared/ui/InfinitePagination';
 import Tabs, { TabMode } from '@/app/components/layout/tabs/Tabs';
@@ -9,6 +9,8 @@ import PortfolioCard from '@/app/components/card/portfolio/PortfolioCard';
 import { PortfolioCardProps } from '@/app/components/card/portfolio/types';
 import { useSearchParams } from 'next/navigation';
 import { PROJECT_TABS, TEAM_TABS, OFFICIAL_TAB, ALL_TAB } from './constants';
+import { Title } from '@/app/components/ui/text/text';
+import { getFoundedYear } from '@/utils/date';
 
 interface CollectClientProps {
   initialProjects?: CardProps[];
@@ -17,9 +19,6 @@ interface CollectClientProps {
   profileName?: string;
 }
 
-/**
- * 포트폴리오 카드를 렌더링하는 helper 함수
- */
 const renderPortfolioCard = (portfolio: PortfolioCardProps, index: number) => (
   <PortfolioCard
     key={index}
@@ -29,9 +28,6 @@ const renderPortfolioCard = (portfolio: PortfolioCardProps, index: number) => (
   />
 );
 
-/**
- * 프로젝트 카드를 렌더링하는 helper 함수
- */
 const renderProjectCard = (project: CardProps) => (
   <Card
     key={project.id}
@@ -54,7 +50,8 @@ export default function CollectClient({
 }: CollectClientProps) {
   const [searchTerm, setSearchTerm] = useState('');
   const searchParams = useSearchParams();
-  const currentTab = (searchParams.get('path') ?? 'all') as TabMode;
+  const defaultTab = type === 'team' ? TEAM_TABS[0] : PROJECT_TABS[0];
+  const currentTab = (searchParams.get('path') ?? defaultTab) as TabMode;
 
   const handleSearchChange = (
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -65,26 +62,19 @@ export default function CollectClient({
   const filteredPortfolios = useMemo(() => {
     if (type !== 'team') return [];
 
-    let filtered = initialPortfolios;
+    let filtered = initialPortfolios.filter(
+      (portfolio) =>
+        currentTab === OFFICIAL_TAB
+          ? portfolio.isOfficial === true
+          : portfolio.isOfficial !== true,
+    );
 
-    // 탭에 따른 필터링 (전공동아리/일반동아리)
-    if (currentTab === OFFICIAL_TAB) {
-      filtered = filtered.filter((portfolio) => portfolio.isOfficial === true);
-    } else if (currentTab !== ALL_TAB) {
-      // 'general' 탭일 때
-      filtered = filtered.filter((portfolio) => portfolio.isOfficial !== true);
-    }
-
-    // 검색어 필터링
     if (searchTerm) {
+      const term = searchTerm.toLowerCase();
       filtered = filtered.filter(
         (portfolio) =>
-          portfolio.profile.name
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase()) ||
-          portfolio.profile.bio
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase()),
+          portfolio.profile.name.toLowerCase().includes(term) ||
+          portfolio.profile.bio.toLowerCase().includes(term),
       );
     }
 
@@ -94,122 +84,89 @@ export default function CollectClient({
   const filteredProjects = useMemo(() => {
     if (type === 'team') return [];
 
-    // 프로젝트 타입인 경우 카테고리별 필터링
-    let filtered = initialProjects;
+    let filtered = initialProjects.filter(
+      (project) => currentTab === ALL_TAB || project.category === currentTab,
+    );
 
-    // 탭에 따른 필터링 (웹, 데스크톱, 모바일)
-    if (currentTab !== ALL_TAB) {
-      // currentTab이 'Web', 'Desktop Utility', 'Mobile' 중 하나일 때 필터링
-      // project_category 테이블의 category_name과 정확히 매칭
-      filtered = filtered.filter((project) => project.category === currentTab);
-    }
-
-    // 검색어 필터링
     if (searchTerm) {
+      const term = searchTerm.toLowerCase();
       filtered = filtered.filter(
         (project) =>
-          (project.title ?? '')
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase()) ||
-          project.description
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase()) ||
-          project.ownerName.toLowerCase().includes(searchTerm.toLowerCase()),
+          (project.title ?? '').toLowerCase().includes(term) ||
+          project.description.toLowerCase().includes(term) ||
+          project.ownerName.toLowerCase().includes(term),
       );
     }
 
     return filtered;
   }, [initialProjects, searchTerm, currentTab, type]);
 
-  const fetchProjects = useCallback(
-    async ({ pageParam }: { pageParam: number }) => {
-      return {
-        data: filteredProjects,
-        totalPages: 1,
-        currentPage: pageParam,
-        hasNextPage: false,
-      };
-    },
-    [filteredProjects],
-  );
+  const teamPortfolios = useMemo(() => {
+    const currentYear = new Date().getFullYear();
+    const withTitle: PortfolioCardProps[] = [];
+    const withoutTitle: PortfolioCardProps[] = [];
+    let generationTitle: string | undefined;
 
-  const fetchPortfolios = useCallback(
-    async ({ pageParam }: { pageParam: number }) => {
-      return {
-        data: filteredPortfolios,
-        totalPages: 1,
-        currentPage: pageParam,
-        hasNextPage: false,
-      };
-    },
-    [filteredPortfolios],
-  );
+    filteredPortfolios.forEach((portfolio) => {
+      if (portfolio.createdAt) {
+        const foundedYear = getFoundedYear(portfolio.createdAt);
+        if (foundedYear === currentYear) {
+          const title = portfolio.isOfficial
+            ? '4기 전공동아리'
+            : `${currentYear}년 일반동아리`;
+          if (!generationTitle) generationTitle = title;
+          withTitle.push(portfolio);
+          return;
+        }
+      }
+      withoutTitle.push(portfolio);
+    });
 
-  // 페이지네이션 없이 그리드로 렌더링하는 공통 컴포넌트
-  const renderStaticGrid = useCallback(() => {
-    if (type === 'team') {
-      return (
-        <div className="grid grid-cols-auto-fit-card gap-6 w-full">
-          {filteredPortfolios.map((portfolio, index) => (
-            <PortfolioCard
-              key={index}
-              profile={portfolio.profile}
-              projects={portfolio.projects}
-              src={`/team/${encodeURIComponent(portfolio.profile.name)}`}
+    return { withTitle, withoutTitle, generationTitle };
+  }, [filteredPortfolios]);
+
+  const createFetchFn = (data: any[]) => async ({ pageParam }: { pageParam: number }) => ({
+    data,
+    totalPages: 1,
+    currentPage: pageParam,
+    hasNextPage: false,
+  });
+
+  const renderTeamPortfolios = (usePagination: boolean) => (
+    <div className="w-full flex flex-col gap-4">
+      {teamPortfolios.generationTitle && (
+        <>
+          <Title className="px-1">{teamPortfolios.generationTitle}</Title>
+          {usePagination ? (
+            <InfinitePagination<PortfolioCardProps>
+              queryKey={['portfolios', searchTerm, currentTab, type, profileName, 'with-title']}
+              queryFn={createFetchFn(teamPortfolios.withTitle)}
+              enabled={true}
+              renderItem={renderPortfolioCard}
             />
-          ))}
-        </div>
-      );
-    }
-
-    return (
-      <div className="grid grid-cols-auto-fit-card gap-6 w-full">
-        {filteredProjects.map((project) => (
-          <Card
-            key={project.id}
-            id={project.id}
-            title={project.title}
-            description={project.description}
-            projectImage={project.projectImage}
-            ownerName={project.ownerName}
-            isTeam={project.isTeam}
-            category={project.category}
-            authors={project.authors}
+          ) : (
+            <div className="grid grid-cols-auto-fit-card gap-6 w-full">
+              {teamPortfolios.withTitle.map((portfolio, index) => renderPortfolioCard(portfolio, index))}
+            </div>
+          )}
+        </>
+      )}
+      {teamPortfolios.withoutTitle.length > 0 && (
+        usePagination ? (
+          <InfinitePagination<PortfolioCardProps>
+            queryKey={['portfolios', searchTerm, currentTab, type, profileName, 'without-title']}
+            queryFn={createFetchFn(teamPortfolios.withoutTitle)}
+            enabled={true}
+            renderItem={renderPortfolioCard}
           />
-        ))}
-      </div>
-    );
-  }, [type, filteredPortfolios, filteredProjects]);
-
-  // 페이지네이션을 사용하여 렌더링하는 공통 컴포넌트
-  const renderPaginatedList = useCallback(() => {
-    if (type === 'team') {
-      return (
-        <InfinitePagination<PortfolioCardProps>
-          queryKey={['portfolios', searchTerm, currentTab, type, profileName]}
-          queryFn={fetchPortfolios}
-          enabled={true}
-          renderItem={renderPortfolioCard}
-        />
-      );
-    }
-
-    return (
-      <InfinitePagination<CardProps>
-        queryKey={['projects', searchTerm, currentTab, type, profileName]}
-        queryFn={fetchProjects}
-        enabled={true}
-        renderItem={renderProjectCard}
-      />
-    );
-  }, [
-    type,
-    searchTerm,
-    currentTab,
-    fetchPortfolios,
-    fetchProjects,
-    profileName,
-  ]);
+        ) : (
+          <div className="grid grid-cols-auto-fit-card gap-6 w-full">
+            {teamPortfolios.withoutTitle.map((portfolio, index) => renderPortfolioCard(portfolio, index))}
+          </div>
+        )
+      )}
+    </div>
+  );
 
   return (
     <div className="flex flex-col items-start gap-6 flex-1 shrink-0">
@@ -222,11 +179,22 @@ export default function CollectClient({
         />
       </div>
 
-      {/* 프로젝트 및 팀 타입별로 다른 탭 표시 */}
       <Tabs tabs={type === 'project' ? PROJECT_TABS : TEAM_TABS} />
 
-      {/* 전공 동아리(official)는 페이지네이션 없이 모두 표시, 나머지는 페이지네이션 사용 */}
-      {currentTab === OFFICIAL_TAB ? renderStaticGrid() : renderPaginatedList()}
+      {type === 'team' ? (
+        renderTeamPortfolios(currentTab !== OFFICIAL_TAB)
+      ) : currentTab === OFFICIAL_TAB ? (
+        <div className="grid grid-cols-auto-fit-card gap-6 w-full">
+          {filteredProjects.map(renderProjectCard)}
+        </div>
+      ) : (
+        <InfinitePagination<CardProps>
+          queryKey={['projects', searchTerm, currentTab, type, profileName]}
+          queryFn={createFetchFn(filteredProjects)}
+          enabled={true}
+          renderItem={renderProjectCard}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/components/feature/collect/CollectClient.tsx
+++ b/src/app/components/feature/collect/CollectClient.tsx
@@ -111,8 +111,10 @@ export default function CollectClient({
       if (portfolio.createdAt) {
         const foundedYear = getFoundedYear(portfolio.createdAt);
         if (foundedYear === currentYear) {
+          // 창립 연도와 현재 연도를 기반으로 기수 계산
+          const generation = currentYear - foundedYear + 1;
           const title = portfolio.isOfficial
-            ? '4기 전공동아리'
+            ? `${generation}기 전공동아리`
             : `${currentYear}년 일반동아리`;
           if (!generationTitle) generationTitle = title;
           withTitle.push(portfolio);

--- a/src/app/components/feature/collect/CollectClient.tsx
+++ b/src/app/components/feature/collect/CollectClient.tsx
@@ -125,7 +125,7 @@ export default function CollectClient({
     return { withTitle, withoutTitle, generationTitle };
   }, [filteredPortfolios]);
 
-  const createFetchFn = (data: any[]) => async ({ pageParam }: { pageParam: number }) => ({
+  const createFetchFn = <T,>(data: T[]) => async ({ pageParam }: { pageParam: number }) => ({
     data,
     totalPages: 1,
     currentPage: pageParam,

--- a/src/app/components/feature/collect/constants.ts
+++ b/src/app/components/feature/collect/constants.ts
@@ -8,7 +8,7 @@ export const PROJECT_TABS: TabMode[] = ['all', 'Web', 'Desktop Utility', 'Mobile
 /**
  * 팀(동아리) 탭 목록
  */
-export const TEAM_TABS: TabMode[] = ['all', 'official', 'general'];
+export const TEAM_TABS: TabMode[] = ['official', 'general'];
 
 /**
  * 전공 동아리를 나타내는 탭 값

--- a/src/app/components/feature/home/HomeProjectList.tsx
+++ b/src/app/components/feature/home/HomeProjectList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import CategoryTag from '@/app/components/ui/tag/CategoryTag';
 import { CardProps } from '@/app/components/card/project/ProjectCard';
 import ProjectGrid from '@/app/components/feature/project/components/ProjectGrid';
@@ -14,7 +14,12 @@ export default function HomeProjectList({ projects }: HomeProjectListProps) {
   const [selectedCategory, setSelectedCategory] = useState<'All' | string>(
     'All',
   );
-  const shuffledProjects = useMemo(() => shuffleArray(projects), [projects]);
+  const [shuffledProjects, setShuffledProjects] = useState<CardProps[]>(projects);
+
+  // Only shuffle on the client side after hydration to prevent hydration mismatch
+  useEffect(() => {
+    setShuffledProjects(shuffleArray(projects));
+  }, [projects]);
 
   const categories = useMemo(() => {
     const uniqueCategories = new Set<string>();

--- a/src/app/components/layout/sidebar/SidebarLayout.tsx
+++ b/src/app/components/layout/sidebar/SidebarLayout.tsx
@@ -21,7 +21,7 @@ const SidebarLayout = ({ header, children, className = '' }: SidebarLayoutProps)
       {header && <div className="pt-[4.5rem]">{header}</div>}
 
       {/* Sticky 영역 */}
-      <aside className={`sticky top-24 self-start mobile:static ${header ? 'mt-[1.625rem]' : 'pt-[4.5rem]'}`}>
+      <aside className={`sticky top-24 self-start mobile:static ${header ? 'mt-4' : 'pt-[4.5rem]'}`}>
         <div className="flex-col w-full gap-[1.625rem]">{children}</div>
       </aside>
     </div>

--- a/src/app/components/layout/tabs/Tabs.tsx
+++ b/src/app/components/layout/tabs/Tabs.tsx
@@ -14,7 +14,7 @@ export type TabMode =
 
 const mapTabValue: Record<TabMode, string> = {
   home: '홈',
-  project: '프로젝트',
+  project: '역대 프로젝트',
   all: '전체',
   official: '전공 동아리',
   general: '일반 동아리',

--- a/src/app/components/modal/inputs/InputListProvider.tsx
+++ b/src/app/components/modal/inputs/InputListProvider.tsx
@@ -94,6 +94,7 @@ const InputListProvider = ({
     Record<string, unknown>[]
   >([]);
   const [showSuggestions, setShowSuggestions] = React.useState(false);
+  const [focusedInputIndex, setFocusedInputIndex] = React.useState<number | null>(null);
   // const [loading, setLoading] = React.useState(false)
   // const [error, setError] = React.useState<string | null>(null)
 
@@ -120,8 +121,9 @@ const InputListProvider = ({
   }, [dropdownInputConfig, showToast]);
 
   // input 클릭/포커스 시 드롭다운 표시
-  const handleInputFocus = () => {
+  const handleInputFocus = (index: number) => {
     if (dropdownInputConfig && tableData.length > 0) {
+      setFocusedInputIndex(index);
       if (onlyOne) {
         // 단일 선택 드롭다운에서는 모든 옵션을 표시 (선택된 값 포함)
         setSuggestions(tableData);
@@ -172,6 +174,7 @@ const InputListProvider = ({
   const handleOptionSelect = () => {
     setShowSuggestions(false);
     setSuggestions([]);
+    setFocusedInputIndex(null);
   };
 
   // inputs가 변경될 때마다 콜백 호출
@@ -179,6 +182,25 @@ const InputListProvider = ({
     onInputsChange?.(inputs);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inputs]);
+
+  // 외부 클릭 시 드롭다운 닫기
+  React.useEffect(() => {
+    const handleClickOutside = () => {
+      if (showSuggestions) {
+        setShowSuggestions(false);
+        setSuggestions([]);
+        setFocusedInputIndex(null);
+      }
+    };
+
+    if (showSuggestions) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [showSuggestions]);
 
   const handleAddInput = () => {
     // maxInputs 체크
@@ -225,9 +247,9 @@ const InputListProvider = ({
           });
         });
         // 삭제 후 드롭다운 열기
-        if (dropdownInputConfig && handleInputFocus) {
+        if (dropdownInputConfig) {
           setTimeout(() => {
-            handleInputFocus();
+            handleInputFocus(index);
           }, 0);
         }
       }
@@ -290,9 +312,9 @@ const InputListProvider = ({
                 },
               }))}
               dropdownInputConfig={dropdownInputConfig}
-              suggestions={showSuggestions ? suggestions : []}
+              suggestions={showSuggestions && focusedInputIndex === index ? suggestions : []}
               onInputChange={handleInputChange}
-              onInputFocus={handleInputFocus}
+              onInputFocus={() => handleInputFocus(index)}
               tableData={tableData}
               onDelete={handleDeleteInput}
               groupIndex={index}

--- a/src/app/components/modal/inputs/SingleInput.tsx
+++ b/src/app/components/modal/inputs/SingleInput.tsx
@@ -29,7 +29,7 @@ const Inputs = ({
   // value 변경 시 높이 조정
   useEffect(() => {
     adjustHeight();
-  }, [textarea, stringValue]);
+  }, [textarea, stringValue, adjustHeight]);
 
   // 포커스 처리
   useEffect(() => {

--- a/src/app/components/ui/input/DropdownInput.tsx
+++ b/src/app/components/ui/input/DropdownInput.tsx
@@ -43,7 +43,6 @@ const DropdownInput = ({
   onInputFocus,
   dropdownInputConfig,
   onOptionSelect,
-  onlyOne = false,
   onDelete,
 }: DropdownInputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/app/components/ui/profile/portfolio/ProfileInfo.tsx
+++ b/src/app/components/ui/profile/portfolio/ProfileInfo.tsx
@@ -33,7 +33,7 @@ const ProfileInfo = ({
 
   // active 상태이고 팀 역할이면 StatusBadge에 role 표시
   const statusBadgeText =
-    profile.status === 'active' && isTeamRole && profile.role.length > 0
+    isTeamRole && profile.role.length > 0
       ? profile.role[0]
       : profile.status;
 

--- a/src/app/components/ui/profile/portfolio/ProfileInfo.tsx
+++ b/src/app/components/ui/profile/portfolio/ProfileInfo.tsx
@@ -21,19 +21,35 @@ const ProfileInfo = ({
 
   const RoleComponent = useLabel ? Label : Caption;
 
+  const isTeamRole = profile.role.some(
+    (role) => role === '전공동아리' || role === '일반동아리',
+  );
+  const roleText =
+    profile.role.length > 0
+      ? isTeamRole
+        ? profile.role.join(', ')
+        : `${profile.role.join(', ')} 희망`
+      : '희망 분야 없음';
+
+  // active 상태이고 팀 역할이면 StatusBadge에 role 표시
+  const statusBadgeText =
+    profile.status === 'active' && isTeamRole && profile.role.length > 0
+      ? profile.role[0]
+      : profile.status;
+
   return (
     <div className={containerClass}>
       <div className="flex-center">
         <Body2>{profile.name}</Body2>
-        <StatusBadge status={profile.status} />
+        <StatusBadge status={statusBadgeText} />
       </div>
-      <RoleComponent className="text-gray-base -mt-1">
-        {profile.role.length > 0
-          ? `${profile.role.join(', ')} 희망`
-          : '희망 분야 없음'}
-      </RoleComponent>
+      {!isTeamRole && (
+        <RoleComponent className="text-gray-base -mt-1">{roleText}</RoleComponent>
+      )}
       {showBio && (
-        <Caption className="text-gray-base truncate">{profile.bio}</Caption>
+        <Caption className="text-gray-base break-words line-clamp-2 h-full">
+          {profile.bio}
+        </Caption>
       )}
     </div>
   );

--- a/src/services/config/projectConfig.ts
+++ b/src/services/config/projectConfig.ts
@@ -389,6 +389,7 @@ export const projectConfig: FormConfig = {
           const { data, error } = await supabase
             .from('profile')
             .select('profile_id, profile_name')
+            .eq('is_team', false)
             .order('profile_name');
           if (error) {
             console.error('Error fetching profiles:', error);

--- a/src/services/core/dataService.graphql.client.ts
+++ b/src/services/core/dataService.graphql.client.ts
@@ -217,8 +217,10 @@ export class GraphQLDataService {
 
         // 업데이트 시 변경하면 안 되는 필드 제거
         // profile의 owner(auth.uid)는 변경 불가하지만, project의 owner(profile_id)는 변경 가능
-        // project_id가 있으면 project 업데이트이므로 owner 유지
-        if (!variables?.project_id) {
+        // mainTable이 'projects'이고 project_id가 있으면 owner 유지, 아니면 제거
+        const mainTable = getMainTable(formConfig);
+        const isProjectsTable = mainTable === 'projects';
+        if (!(isProjectsTable && variables?.project_id)) {
           delete updateSet.owner; // profile 업데이트인 경우에만 owner 제거
         }
         delete updateSet.is_team;

--- a/src/services/core/dataService.graphql.client.ts
+++ b/src/services/core/dataService.graphql.client.ts
@@ -243,8 +243,7 @@ export class GraphQLDataService {
 
         // 🔥 핵심 수정: 테이블별 적절한 filter 필드 선택
         // 프로젝트 테이블인 경우 profile_id 사용하지 않음
-        const mainTable = getMainTable(formConfig);
-        const isProjectsTable = mainTable === 'projects';
+        // mainTable은 위에서 이미 선언됨
 
         const filterField = isProjectsTable && variables?.project_id
           ? 'project_id'

--- a/src/services/core/dataService.graphql.client.ts
+++ b/src/services/core/dataService.graphql.client.ts
@@ -211,12 +211,15 @@ export class GraphQLDataService {
       let finalVariables: Record<string, unknown>;
 
       if (isUpdate) {
-        // Update: $set에는 실제 변경할 필드만 포함 (owner, is_team 제외)
-        // owner와 is_team은 filter에만 사용
+        // Update: $set에는 실제 변경할 필드만 포함
         const updateSet = { ...mainTableData };
 
         // 업데이트 시 변경하면 안 되는 필드 제거
-        delete updateSet.owner;
+        // profile의 owner(auth.uid)는 변경 불가하지만, project의 owner(profile_id)는 변경 가능
+        // project_id가 있으면 project 업데이트이므로 owner 유지
+        if (!variables?.project_id) {
+          delete updateSet.owner; // profile 업데이트인 경우에만 owner 제거
+        }
         delete updateSet.is_team;
         delete updateSet.project_id;
 

--- a/src/services/graphQL/relationTableHelper.graphql.ts
+++ b/src/services/graphQL/relationTableHelper.graphql.ts
@@ -315,7 +315,6 @@ export async function updateProfileCompetitions(
 export async function updateStudentJobs(
   studentId: string,
   jobIds: number[],
-  existingJobs: Array<{ job_id: number }> = [],
 ): Promise<void> {
   const supabase = createClient();
 

--- a/src/services/profile/saveProfile.client.ts
+++ b/src/services/profile/saveProfile.client.ts
@@ -404,3 +404,4 @@ export async function saveProfileData(
     return { success: false, error: '예상치 못한 오류가 발생했습니다.' };
   }
 }
+

--- a/src/services/team/getTeamProjects.server.ts
+++ b/src/services/team/getTeamProjects.server.ts
@@ -12,6 +12,7 @@ export const getTeamProjects = async (teamName: string): Promise<TeamProjectType
       project_name,
       project_thumbnail,
       description,
+      created_at,
       profile!projects_owner_fkey!inner (
         profile_name,
         is_team
@@ -26,6 +27,7 @@ export const getTeamProjects = async (teamName: string): Promise<TeamProjectType
     `)
     .eq('profile.profile_name', teamName)
     .eq('profile.is_team', true)
+    .order('created_at', { ascending: false })
 
   if (error) {
     console.error('팀 프로젝트 조회 중 오류', error)

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -34,7 +34,7 @@ export const formatEndDate = (data: string | null): string => {
 
 /**
  * datetime을 넣었을 때 창립년도를 반환하는 함수
- * @param dateString - ISO 8601 형식의 날짜 문자열 또는 null
+ * @param dateString - 날짜 문자열 (Date 생성자가 파싱 가능한 형식) 또는 null
  * @returns 유효한 날짜의 경우 연도(number), null이거나 유효하지 않은 날짜인 경우 -1
  */
 export const getFoundedYear = (dateString: string | null): number => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -34,7 +34,7 @@ export const formatEndDate = (data: string | null): string => {
 
 // datetime을 넣었을 때 창립년도를 반환하는 함수
 export const getFoundedYear = (dateString: string | null): number => {
-  if (!dateString) return 0;
+  if (!dateString) return -1;
 
   return new Date(dateString).getFullYear();
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -36,5 +36,9 @@ export const formatEndDate = (data: string | null): string => {
 export const getFoundedYear = (dateString: string | null): number => {
   if (!dateString) return -1;
 
-  return new Date(dateString).getFullYear();
+  const date = new Date(dateString);
+  // 유효하지 않은 날짜인 경우 -1 반환
+  if (isNaN(date.getTime())) return -1;
+
+  return date.getFullYear();
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -32,7 +32,11 @@ export const formatEndDate = (data: string | null): string => {
   return data ? ` ~ ${data}` : '';
 };
 
-// datetime을 넣었을 때 창립년도를 반환하는 함수
+/**
+ * datetime을 넣었을 때 창립년도를 반환하는 함수
+ * @param dateString - ISO 8601 형식의 날짜 문자열 또는 null
+ * @returns 유효한 날짜의 경우 연도(number), null이거나 유효하지 않은 날짜인 경우 -1
+ */
 export const getFoundedYear = (dateString: string | null): number => {
   if (!dateString) return -1;
 

--- a/src/utils/transformTeamToPortfolioCard.ts
+++ b/src/utils/transformTeamToPortfolioCard.ts
@@ -5,7 +5,6 @@ import {
 } from '@/app/components/card/portfolio/types';
 import { TeamData } from '@/app/(box-layout)/team/types';
 import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
-import { getFoundedYear } from '@/utils/date';
 
 /**
  * 팀 데이터를 포트폴리오 카드 컴포넌트 props로 변환

--- a/src/utils/transformTeamToPortfolioCard.ts
+++ b/src/utils/transformTeamToPortfolioCard.ts
@@ -5,6 +5,7 @@ import {
 } from '@/app/components/card/portfolio/types';
 import { TeamData } from '@/app/(box-layout)/team/types';
 import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
+import { getFoundedYear } from '@/utils/date';
 
 /**
  * 팀 데이터를 포트폴리오 카드 컴포넌트 props로 변환
@@ -42,5 +43,6 @@ export function transformTeamToPortfolioCard(
     profile,
     projects,
     isOfficial: team.is_official ?? false,
+    createdAt: team.created_at,
   };
 }


### PR DESCRIPTION
## 💡 개요

팀 페이지의 사용자 경험을 개선하기 위해 다음과 같은 기능을 추가했습니다:
1. 올해 창설된 전공동아리/일반동아리에 기수 표시 (4기 전공동아리, 2025년 일반동아리)
2. 팀 카드 UI 개선 (희망 텍스트 제거, StatusBadge에 동아리 타입 표시)
3. 팀 상세 페이지에 홈/역대 프로젝트 탭 추가 및 년도별 그룹화 기능

## 📃 작업내용

### 1. 올해 창설된 동아리 기수 표시

팀 목록 페이지에서 올해 창설된 동아리를 구분하여 표시합니다.

```mermaid
graph TD
    A[팀 데이터 조회] --> B[created_at 연도 확인]
    B --> C{올해 창설?}
    C -->|Yes| D{전공동아리?}
    C -->|No| E[일반 표시]
    D -->|Yes| F[4기 전공동아리 Title 표시]
    D -->|No| G[2025년 일반동아리 Title 표시]
    F --> H[해당 그룹 카드 렌더링]
    G --> H
    E --> I[일반 그룹 카드 렌더링]
```

### 2. 팀 카드 UI 개선

PortfolioCard에서 팀일 때 불필요한 정보를 제거하고 동아리 타입을 명확히 표시합니다.

```mermaid
graph TD
    A[PortfolioCard 렌더링] --> B{팀 역할인가?}
    B -->|Yes| C[roleText 숨김]
    B -->|No| D[희망 텍스트 표시]
    C --> E[StatusBadge에 동아리 타입 표시]
    E --> F[bio 텍스트 줄바꿈 처리]
    D --> F
```

### 3. 팀 상세 페이지 탭 기능

팀 상세 페이지에 홈/역대 프로젝트 탭을 추가하고, 역대 프로젝트는 년도별로 그룹화하여 표시합니다.

```mermaid
graph TD
    A[팀 상세 페이지 접속] --> B[프로젝트 데이터 조회]
    B --> C[created_at 기준 년도 추출]
    C --> D[년도별 그룹화]
    D --> E{탭 선택}
    E -->|홈| F[모든 프로젝트 최신순 표시]
    E -->|역대 프로젝트| G[년도 내림차순 정렬]
    G --> H[각 년도별 섹션 렌더링]
    H --> I[해당 년도 프로젝트 그리드 표시]
```

## 🔀 변경사항

### 추가 개선사항

1. **팀 목록 페이지 개선**
   - "전체" 탭 제거 (전공동아리/일반동아리 탭만 유지)
   - 기본 탭을 TEAM_TABS[0]으로 동적 설정
   - generationTitle prop 제거 및 createdAt으로 리팩토링

2. **코드 최적화**
   - CollectClient 컴포넌트 리팩토링 (317줄 → 201줄)
   - 중복 로직 제거 및 useMemo 활용
   - TeamProjectsByYear 컴포넌트 인라인화

3. **타입 안정성 개선**
   - TeamProjectType에 created_at 필드 추가
   - 프로젝트 정렬을 서버에서 처리 (created_at DESC)

## 📸 스크린샷
<img width="1084" height="734" alt="image" src="https://github.com/user-attachments/assets/00b09724-3770-46db-971e-e1c3acf5c7cc" />
<img width="2668" height="1175" alt="image" src="https://github.com/user-attachments/assets/169ec04e-06a2-44bb-812b-2420118b9c53" />
<img width="2631" height="920" alt="image" src="https://github.com/user-attachments/assets/5aa69fe2-97af-4f46-963c-588f50bdffbd" />
