### PR TITLE
(I25-285)-feat/프로필-정렬기준-만들기

### DIFF
--- a/src/app/(root)/page.tsx
+++ b/src/app/(root)/page.tsx
@@ -8,11 +8,23 @@ import getAccount from '@/services/auth/getAccount.server';
 import AutoCarousel from '../components/card/home/AutoCarousel';
 import fs from 'node:fs';
 import path from 'node:path';
+import { sortProjectsByThumbnailAndGrade } from '@/utils/project/sortProjects';
+import { getProjectSortData } from '@/services/project/getProjectSortData.server';
 
 const ALLOWED_EXTENSIONS = new Set(['.png']);
 
 export default async function Home() {
   const projects = await getProjects();
+
+  // 정렬을 위한 추가 데이터 조회
+  const projectIds = projects.map((p) => p.id);
+  const sortDataMap = await getProjectSortData(projectIds);
+
+  // 프로젝트 정렬
+  const sortedProjects = sortProjectsByThumbnailAndGrade(
+    projects,
+    sortDataMap,
+  );
 
   const user = await getAccount();
 
@@ -48,7 +60,7 @@ export default async function Home() {
           </div>
         </div>
       </div>
-      <ProjectList projects={projects} />
+      <ProjectList projects={sortedProjects} />
     </div>
   );
 }

--- a/src/app/components/feature/collect/CollectClient.tsx
+++ b/src/app/components/feature/collect/CollectClient.tsx
@@ -11,6 +11,10 @@ import { useSearchParams } from 'next/navigation';
 import { PROJECT_TABS, TEAM_TABS, OFFICIAL_TAB, ALL_TAB } from './constants';
 import { Title } from '@/app/components/ui/text/text';
 import { getFoundedYear } from '@/utils/date';
+import {
+  calculateGeneration,
+  getCurrentYear,
+} from '@/utils/student/studentCalculations';
 
 interface CollectClientProps {
   initialProjects?: CardProps[];
@@ -102,7 +106,7 @@ export default function CollectClient({
   }, [initialProjects, searchTerm, currentTab, type]);
 
   const teamPortfolios = useMemo(() => {
-    const currentYear = new Date().getFullYear();
+    const currentYear = getCurrentYear();
     const withTitle: PortfolioCardProps[] = [];
     const withoutTitle: PortfolioCardProps[] = [];
     let generationTitle: string | undefined;
@@ -112,7 +116,7 @@ export default function CollectClient({
         const foundedYear = getFoundedYear(portfolio.createdAt);
         if (foundedYear === currentYear) {
           // 창립 연도와 현재 연도를 기반으로 기수 계산
-          const generation = currentYear - foundedYear + 1;
+          const generation = calculateGeneration(foundedYear, currentYear);
           const title = portfolio.isOfficial
             ? `${generation}기 전공동아리`
             : `${currentYear}년 일반동아리`;

--- a/src/app/components/feature/home/HomeProjectList.tsx
+++ b/src/app/components/feature/home/HomeProjectList.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 import CategoryTag from '@/app/components/ui/tag/CategoryTag';
 import { CardProps } from '@/app/components/card/project/ProjectCard';
 import ProjectGrid from '@/app/components/feature/project/components/ProjectGrid';
-import { shuffleArray } from '@/utils/shuffle';
 
 interface HomeProjectListProps {
   projects: CardProps[];
@@ -14,12 +13,6 @@ export default function HomeProjectList({ projects }: HomeProjectListProps) {
   const [selectedCategory, setSelectedCategory] = useState<'All' | string>(
     'All',
   );
-  const [shuffledProjects, setShuffledProjects] = useState<CardProps[]>(projects);
-
-  // Only shuffle on the client side after hydration to prevent hydration mismatch
-  useEffect(() => {
-    setShuffledProjects(shuffleArray(projects));
-  }, [projects]);
 
   const categories = useMemo(() => {
     const uniqueCategories = new Set<string>();
@@ -35,11 +28,11 @@ export default function HomeProjectList({ projects }: HomeProjectListProps) {
 
   const filteredProjects = useMemo(() => {
     return selectedCategory === 'All'
-      ? shuffledProjects
-      : shuffledProjects.filter(
+      ? projects
+      : projects.filter(
           (project) => project.category === selectedCategory,
         );
-  }, [shuffledProjects, selectedCategory]);
+  }, [projects, selectedCategory]);
 
   return (
     <div className="flex-col gap-[0.90625rem] w-full">

--- a/src/services/profile/saveProfile.client.ts
+++ b/src/services/profile/saveProfile.client.ts
@@ -396,7 +396,7 @@ export async function saveProfileData(
 
     // 희망직무 처리 (단일 선택이므로 job_id가 하나만 있을 수 있음)
     // updateStudentJobs 함수를 재사용하여 upsert 로직 중복 제거
-    await updateStudentJobs(userId, saveData.studentJobs, []);
+    await updateStudentJobs(userId, saveData.studentJobs);
 
     return { success: true };
   } catch (error) {

--- a/src/services/project/getProjectSortData.server.ts
+++ b/src/services/project/getProjectSortData.server.ts
@@ -1,0 +1,68 @@
+import { createClient } from '@/services/supabase/server';
+import type { ProjectSortData } from '@/utils/project/sortProjects';
+
+type ProjectWithProfile = {
+  project_id: number;
+  created_at: string | null;
+  project_html_description: string | null;
+  profile: {
+    profile_id: string;
+    is_team: boolean;
+    student?: { join_at: string } | null;
+  } | null;
+};
+
+/**
+ * 프로젝트 정렬을 위한 추가 데이터 조회
+ */
+export async function getProjectSortData(
+  projectIds: number[],
+): Promise<Map<number, ProjectSortData>> {
+  const sortDataMap = new Map<number, ProjectSortData>();
+
+  if (projectIds.length === 0) return sortDataMap;
+
+  const supabase = await createClient();
+
+  const { data: projects, error } = await supabase
+    .from('projects')
+    .select(
+      `
+      project_id,
+      created_at,
+      project_html_description,
+      profile!projects_owner_fkey (
+        profile_id,
+        is_team,
+        student!profile_owner_fkey1 (
+          join_at
+        )
+      )
+    `,
+    )
+    .in('project_id', projectIds)
+    .returns<ProjectWithProfile[]>();
+
+  if (error) {
+    console.error('프로젝트 정렬 데이터 조회 중 오류:', error);
+    return sortDataMap;
+  }
+
+  projects?.forEach((project) => {
+    const profile = project.profile;
+
+    if (profile) {
+      sortDataMap.set(project.project_id, {
+        projectId: project.project_id,
+        isTeam: profile.is_team,
+        joinAt: profile.student?.join_at ?? null,
+        createdAt: project.created_at ?? null,
+        hasHtmlDescription:
+          !!project.project_html_description &&
+          project.project_html_description.trim() !== '',
+      });
+    }
+  });
+
+  return sortDataMap;
+}

--- a/src/utils/convertStudentNumber.ts
+++ b/src/utils/convertStudentNumber.ts
@@ -1,8 +1,11 @@
-// 0000 형식의 학번을 '0반 0번' 형식으로 바꿔주는 함수
+import { calculateGradeFromStudentNumber } from './student/studentCalculations';
+
+// 0000 형식의 학번을 '0학년 0반' 형식으로 바꿔주는 함수
 export const convertStudentNumber = (student_number: number | null): string => {
   if (!student_number) return '';
 
   const studentNumber = student_number.toString();
+  const grade = calculateGradeFromStudentNumber(student_number);
 
-  return `${studentNumber[0]}학년 ${studentNumber[1]}반`
-}
+  return `${grade}학년 ${studentNumber[1] || ''}반`;
+};

--- a/src/utils/project/sortProjects.ts
+++ b/src/utils/project/sortProjects.ts
@@ -20,7 +20,7 @@ export interface ProjectSortData {
  * 프로젝트의 학년을 계산
  * @param project - CardProps
  * @param sortData - 정렬을 위한 추가 데이터
- * @returns 학년 (3, 2, 1), 계산 불가능한 경우 0
+ * @returns 학년 (1, 2, 3, 4), 계산 불가능한 경우 0
  */
 function calculateProjectGrade(
   project: CardProps,

--- a/src/utils/project/sortProjects.ts
+++ b/src/utils/project/sortProjects.ts
@@ -1,0 +1,107 @@
+import { CardProps } from '@/app/components/card/project/ProjectCard';
+import {
+  calculateGradeFromJoinAt,
+  extractYearFromDate,
+  getCurrentYear,
+} from '@/utils/student/studentCalculations';
+
+/**
+ * 프로젝트 정렬을 위한 추가 데이터 타입
+ */
+export interface ProjectSortData {
+  projectId: number;
+  isTeam: boolean;
+  joinAt?: string | null; // 학생의 입학년도 (개인 프로젝트용)
+  createdAt?: string | null; // 프로젝트 생성년도 (팀 프로젝트용)
+  hasHtmlDescription: boolean; // HTML 설명 유무
+}
+
+/**
+ * 프로젝트의 학년을 계산
+ * @param project - CardProps
+ * @param sortData - 정렬을 위한 추가 데이터
+ * @returns 학년 (3, 2, 1), 계산 불가능한 경우 0
+ */
+function calculateProjectGrade(
+  project: CardProps,
+  sortData: ProjectSortData | undefined,
+): number {
+  if (!sortData) return 0;
+
+  // 팀 프로젝트: 프로젝트 생성년도로 계산
+  if (project.isTeam && sortData.createdAt) {
+    const createdYear = extractYearFromDate(sortData.createdAt);
+    if (createdYear === -1) return 0;
+
+    const currentYear = getCurrentYear();
+    const grade = currentYear - createdYear + 1;
+
+    // 학년 범위 제한 (1~3학년)
+    return grade >= 1 && grade <= 3 ? grade : 0;
+  }
+
+  // 개인 프로젝트: 학생의 입학년도로 계산
+  return !project.isTeam && sortData.joinAt
+    ? calculateGradeFromJoinAt(sortData.joinAt)
+    : 0;
+}
+
+/**
+ * 프로젝트에 실제 썸네일이 있는지 확인
+ * 기본 썸네일 URL은 썸네일이 없는 것으로 처리
+ * @param projectImage - 프로젝트 이미지 URL
+ * @returns 실제 썸네일이 있으면 true, 없으면 false
+ */
+function hasRealThumbnail(projectImage: string | undefined): boolean {
+  if (!projectImage || projectImage.trim() === '') return false;
+
+  // 기본 썸네일 URL은 썸네일이 없는 것으로 처리
+  return !projectImage.includes('project_default_thumbnail');
+}
+
+/**
+ * 프로젝트를 썸네일 유무, HTML 설명 유무, 학년 기준으로 정렬
+ * 정렬 우선순위:
+ * 1. 썸네일 유무 (썸네일이 있는 프로젝트가 위로)
+ * 2. HTML 설명 유무 (HTML 설명이 있는 프로젝트가 위로)
+ * 3. 학년 (3학년 > 2학년 > 1학년 > 0)
+ *
+ * @param projects - 정렬할 프로젝트 배열
+ * @param sortDataMap - 프로젝트 ID를 키로 하는 정렬 데이터 맵
+ * @returns 정렬된 프로젝트 배열
+ */
+export function sortProjectsByThumbnailAndGrade(
+  projects: CardProps[],
+  sortDataMap: Map<number, ProjectSortData>,
+): CardProps[] {
+  return [...projects].sort((a, b) => {
+    const sortDataA = sortDataMap.get(a.id);
+    const sortDataB = sortDataMap.get(b.id);
+
+    // 1순위: 썸네일 유무
+    const hasThumbnailA = hasRealThumbnail(a.projectImage);
+    const hasThumbnailB = hasRealThumbnail(b.projectImage);
+
+    if (hasThumbnailA !== hasThumbnailB) {
+      // 썸네일이 있는 프로젝트가 위로
+      return hasThumbnailA ? -1 : 1;
+    }
+
+    // 2순위: HTML 설명 유무
+    const hasHtmlDescA = sortDataA?.hasHtmlDescription ?? false;
+    const hasHtmlDescB = sortDataB?.hasHtmlDescription ?? false;
+
+    if (hasHtmlDescA !== hasHtmlDescB) {
+      // HTML 설명이 있는 프로젝트가 위로
+      return hasHtmlDescA ? -1 : 1;
+    }
+
+    // 3순위: 학년별 정렬 (3학년 > 2학년 > 1학년 > 0)
+    const gradeA = calculateProjectGrade(a, sortDataA);
+    const gradeB = calculateProjectGrade(b, sortDataB);
+
+    // 학년이 높은 순서대로 (3 > 2 > 1 > 0)
+    return gradeB - gradeA;
+  });
+}
+

--- a/src/utils/project/sortProjects.ts
+++ b/src/utils/project/sortProjects.ts
@@ -41,9 +41,11 @@ function calculateProjectGrade(
   }
 
   // 개인 프로젝트: 학생의 입학년도로 계산
-  return !project.isTeam && sortData.joinAt
-    ? calculateGradeFromJoinAt(sortData.joinAt)
-    : 0;
+  if (!project.isTeam && sortData.joinAt) {
+    const grade = calculateGradeFromJoinAt(sortData.joinAt);
+    return grade >= 1 && grade <= 3 ? grade : 0;
+  }
+  return 0;
 }
 
 /**

--- a/src/utils/student/studentCalculations.ts
+++ b/src/utils/student/studentCalculations.ts
@@ -1,0 +1,85 @@
+/**
+ * 학생 관련 계산 유틸리티 함수들
+ * 학년, 기수, 년도 계산을 위한 공통 모듈
+ */
+
+/**
+ * 현재 연도 반환
+ * @returns 현재 연도 (number)
+ */
+export function getCurrentYear(): number {
+  return new Date().getFullYear();
+}
+
+/**
+ * 날짜 문자열에서 연도 추출
+ * @param dateString - 날짜 문자열 (Date 생성자가 파싱 가능한 형식)
+ * @returns 유효한 날짜의 경우 연도(number), 유효하지 않은 경우 -1
+ */
+export function extractYearFromDate(dateString: string | null): number {
+  if (!dateString) return -1;
+
+  const date = new Date(dateString);
+  // 유효하지 않은 날짜인 경우 -1 반환
+  if (isNaN(date.getTime())) return -1;
+
+  return date.getFullYear();
+}
+
+/**
+ * 입학년도(join_at)로 현재 학년 계산
+ * 현재 연도 기준: 현재 연도 - 입학년도 + 1 = 학년
+ * @param joinAt - 입학년도 날짜 문자열
+ * @returns 학년 (1, 2, 3), 계산 불가능한 경우 0
+ */
+export function calculateGradeFromJoinAt(joinAt: string | null): number {
+  if (!joinAt) return 0;
+
+  const joinYear = extractYearFromDate(joinAt);
+  if (joinYear === -1) return 0;
+
+  const currentYear = getCurrentYear();
+  const grade = currentYear - joinYear + 1;
+
+  // 학년은 1~4학년 범위로 제한 (일반적인 대학 학제 기준)
+  if (grade < 1) return 0;
+  if (grade > 4) return 0; // 졸업생도 0으로 처리
+
+  return grade;
+}
+
+/**
+ * 학번에서 학년 추출
+ * 학번 형식: 0000 (첫 번째 자리수가 학년)
+ * @param studentNumber - 학번 (number)
+ * @returns 학년 (1, 2, 3, 4), 계산 불가능한 경우 0
+ */
+export function calculateGradeFromStudentNumber(
+  studentNumber: number | null,
+): number {
+  if (!studentNumber) return 0;
+
+  const studentNumberStr = studentNumber.toString();
+  if (studentNumberStr.length < 1) return 0;
+
+  const grade = parseInt(studentNumberStr[0], 10);
+  if (isNaN(grade) || grade < 1 || grade > 4) return 0;
+
+  return grade;
+}
+
+/**
+ * 기수 계산
+ * 현재 연도 기준: 현재 연도 - 창립년도 + 1 = 기수
+ * @param foundedYear - 창립년도
+ * @param currentYear - 현재 연도 (선택적, 기본값은 현재 연도)
+ * @returns 기수 (number)
+ */
+export function calculateGeneration(
+  foundedYear: number,
+  currentYear?: number,
+): number {
+  const year = currentYear ?? getCurrentYear();
+  return year - foundedYear + 1;
+}
+

--- a/src/utils/student/studentCalculations.ts
+++ b/src/utils/student/studentCalculations.ts
@@ -60,7 +60,6 @@ export function calculateGradeFromStudentNumber(
   if (!studentNumber) return 0;
 
   const studentNumberStr = studentNumber.toString();
-  if (studentNumberStr.length < 1) return 0;
 
   const grade = parseInt(studentNumberStr[0], 10);
   if (isNaN(grade) || grade < 1 || grade > 4) return 0;

--- a/src/utils/student/studentCalculations.ts
+++ b/src/utils/student/studentCalculations.ts
@@ -30,7 +30,7 @@ export function extractYearFromDate(dateString: string | null): number {
  * 입학년도(join_at)로 현재 학년 계산
  * 현재 연도 기준: 현재 연도 - 입학년도 + 1 = 학년
  * @param joinAt - 입학년도 날짜 문자열
- * @returns 학년 (1, 2, 3), 계산 불가능한 경우 0
+ * @returns 학년 (1, 2, 3, 4), 계산 불가능한 경우 0
  */
 export function calculateGradeFromJoinAt(joinAt: string | null): number {
   if (!joinAt) return 0;


### PR DESCRIPTION
## 💡 개요

홈 페이지의 프로젝트 목록에 정렬 기준을 적용하여 사용자 경험을 개선했습니다. 프로젝트를 썸네일 유무, HTML 설명 유무, 학년 순으로 정렬하여 더 완성도 높은 프로젝트가 상단에 표시되도록 구현했습니다.

## 📃 작업내용

### 1. 프로젝트 정렬 기준 구현

프로젝트를 다음 우선순위로 정렬합니다:
1. **썸네일 유무**: 썸네일이 있는 프로젝트가 위로
2. **HTML 설명 유무**: HTML 설명이 있는 프로젝트가 위로
3. **학년**: 3학년 > 2학년 > 1학년 > 0 순서

```mermaid
graph TD
    A[프로젝트 목록 조회] --> B[프로젝트 ID 추출]
    B --> C[getProjectSortData 호출]
    C --> D[Supabase에서 정렬 데이터 조회]
    D --> E[학년, HTML 설명 유무 등 데이터 수집]
    E --> F[sortProjectsByThumbnailAndGrade 실행]
    F --> G{썸네일 유무 비교}
    G -->|다름| H[썸네일 있는 프로젝트 우선]
    G -->|같음| I{HTML 설명 유무 비교}
    I -->|다름| J[HTML 설명 있는 프로젝트 우선]
    I -->|같음| K{학년 비교}
    K --> L[학년 높은 순서로 정렬]
    H --> M[정렬된 프로젝트 목록 반환]
    J --> M
    L --> M
```

### 2. 정렬 데이터 조회 함수 구현

프로젝트 정렬에 필요한 추가 데이터를 효율적으로 조회하는 함수를 구현했습니다.

```mermaid
graph TD
    A[getProjectSortData 호출] --> B{프로젝트 ID 존재?}
    B -->|없음| C[빈 Map 반환]
    B -->|있음| D[Supabase 쿼리 실행]
    D --> E[projects 테이블 조회]
    E --> F[profile, student 정보 조인]
    F --> G[각 프로젝트별 데이터 추출]
    G --> H[ProjectSortData 객체 생성]
    H --> I[Map에 저장]
    I --> J[정렬 데이터 Map 반환]
```

### 3. 학년 계산 로직 통합

학생 관련 계산 로직을 공통 유틸리티 함수로 통합하여 재사용성을 높였습니다.

```mermaid
graph TD
    A[학년 계산 필요] --> B{프로젝트 타입}
    B -->|팀 프로젝트| C[프로젝트 생성년도 사용]
    B -->|개인 프로젝트| D[학생 입학년도 사용]
    C --> E[extractYearFromDate 호출]
    D --> F[calculateGradeFromJoinAt 호출]
    E --> G[현재 연도 - 생성년도 + 1]
    F --> H[현재 연도 - 입학년도 + 1]
    G --> I[학년 범위 검증 1~3]
    H --> I
    I --> J[학년 반환]
```

### 4. 주요 구현 내용

1. **정렬 데이터 조회 함수** (`getProjectSortData.server.ts`)
   - 프로젝트 ID 배열을 받아 정렬에 필요한 데이터를 일괄 조회
   - 프로젝트 생성일, 소유자 프로필 정보, 학생 입학년도, HTML 설명 유무 수집
   - Map 자료구조로 O(1) 조회 성능 보장

2. **프로젝트 정렬 함수** (`sortProjectsByThumbnailAndGrade`)
   - 썸네일 유무 확인 (기본 썸네일 제외)
   - HTML 설명 유무 확인
   - 학년 계산 및 비교
   - 다중 기준 정렬 구현

3. **학생 계산 유틸리티** (`studentCalculations.ts`)
   - `getCurrentYear`: 현재 연도 반환
   - `extractYearFromDate`: 날짜 문자열에서 연도 추출
   - `calculateGradeFromJoinAt`: 입학년도로 현재 학년 계산
   - `calculateGradeFromStudentNumber`: 학번으로 학년 추출
   - `calculateGeneration`: 기수 계산

4. **홈 페이지 정렬 적용** (`page.tsx`)
   - 프로젝트 조회 후 정렬 데이터 수집
   - 정렬 함수 실행하여 정렬된 프로젝트 목록 생성
   - 정렬된 프로젝트를 `ProjectList` 컴포넌트에 전달

## 🔀 변경사항

### 추가 개선사항

1. **학생 계산 로직 통합**
   - 분산되어 있던 학년 계산 로직을 `studentCalculations.ts`로 통합
   - 코드 재사용성 및 유지보수성 향상

2. **정렬 성능 최적화**
   - Map 자료구조 사용으로 정렬 시 O(1) 조회 성능 보장
   - 프로젝트 ID 배열을 한 번에 조회하여 N+1 쿼리 문제 방지

3. **타입 안전성 개선**
   - `ProjectSortData` 인터페이스 정의로 타입 안전성 향상
   - null/undefined 처리로 런타임 에러 방지

## 주요 파일 변경

- `src/services/project/getProjectSortData.server.ts` (신규)
- `src/utils/project/sortProjects.ts` (신규)
- `src/utils/student/studentCalculations.ts` (신규)
- `src/app/(root)/page.tsx`

