### PR TITLE
I25 314 스킬태그 기여자 수정 추가 불가 오류 수정

### DIFF
--- a/src/app/components/feature/project/components/ProjectEditModal.tsx
+++ b/src/app/components/feature/project/components/ProjectEditModal.tsx
@@ -103,6 +103,7 @@ const ProjectEditModal = ({
       onSubmit={canSave ? handleProjectSubmit : undefined}
       onDelete={mode === 'update' ? handleProjectDelete : undefined}
       mode={mode}
+      onClose={onClose}
     />
   );
 };

--- a/src/app/components/modal/inputs/InputListProvider.tsx
+++ b/src/app/components/modal/inputs/InputListProvider.tsx
@@ -126,6 +126,7 @@ const InputListProvider = ({
       setFocusedInputIndex(index);
       if (onlyOne) {
         // 단일 선택 드롭다운에서는 모든 옵션을 표시 (선택된 값 포함)
+        // tableData는 이미 query에서 필터링됨
         setSuggestions(tableData);
       } else {
         // 복수 선택 드롭다운에서는 이미 선택된 값들을 제외한 옵션 표시
@@ -257,7 +258,7 @@ const InputListProvider = ({
     }
     
     dispatch({ type: 'DELETE_INPUT', index });
-    
+
     // 복수 드롭다운에서 삭제 후 드롭다운 열기
     if (dropdownInputConfig && tableData.length > 0) {
       setTimeout(() => {

--- a/src/app/components/modal/inputs/InputListProvider.tsx
+++ b/src/app/components/modal/inputs/InputListProvider.tsx
@@ -28,7 +28,7 @@ export type InputConfig = {
 export type DropdownInputConfig = {
   nameColumnName: string;
   valueColumnName: string;
-  query?: () => Promise<Record<string, unknown>[]>;
+  query?: (formData?: Record<string, unknown>) => Promise<Record<string, unknown>[]>;
 };
 
 interface InputListProviderProps {
@@ -39,6 +39,7 @@ interface InputListProviderProps {
   onlyOne?: boolean;
   required?: boolean;
   onInputsChange?: (inputs: MultiInputItem[][]) => void;
+  currentFormData?: Record<string, unknown>;
 }
 
 // 프레젠테이션 컴포넌트
@@ -51,6 +52,7 @@ const InputListProvider = ({
   // maxInputs,
   onlyOne = config.onlyOne ?? false,
   required = false,
+  currentFormData,
 }: InputListProviderProps) => {
   // config를 MultiInputItem으로 변환
   const initialConfig = config.inputs.map((input) => ({
@@ -105,7 +107,7 @@ const InputListProvider = ({
     if (dropdownInputConfig?.query) {
       // 커스텀 쿼리 함수가 있으면 사용
       dropdownInputConfig
-        .query()
+        .query(currentFormData)
         .then((data) => {
           setTableData(data);
         })
@@ -118,7 +120,7 @@ const InputListProvider = ({
           );
         });
     }
-  }, [dropdownInputConfig, showToast]);
+  }, [dropdownInputConfig, showToast, currentFormData]);
 
   // input 클릭/포커스 시 드롭다운 표시
   const handleInputFocus = (index: number) => {

--- a/src/app/components/ui/input/InputOfModal.tsx
+++ b/src/app/components/ui/input/InputOfModal.tsx
@@ -36,7 +36,7 @@ const InputOfModal = ({
   mode,
   onClose,
 }: InputOfModalProps) => {
-  const { control, handleSubmit, formState: { errors }, reset } = useForm({
+  const { control, handleSubmit, formState: { errors }, reset, watch } = useForm({
     defaultValues: config.fields.reduce((acc: Record<string, MultiInputItem[][] | number[] | string[] | boolean | File | null>, field) => {
       // 초기값이 제공된 경우 사용, 그렇지 않으면 기본값 사용
       if (initialValues && initialValues[field.fieldName] !== undefined) {
@@ -51,6 +51,14 @@ const InputOfModal = ({
       return acc;
     }, {} as Record<string, MultiInputItem[][] | string[] | boolean | File | null>)
   });
+
+  // 현재 폼 데이터를 watch로 추적하고 mode 및 owner 정보 추가
+  const formValues = watch();
+  const currentFormData = {
+    ...formValues,
+    _mode: mode, // mode 정보 추가
+    owner: (initialValues as Record<string, unknown>)?.owner, // owner 정보 추가 (update 모드에서 사용)
+  };
 
   const { openModal, closeModal } = useModal();
   const { showToast } = useToast();
@@ -192,6 +200,7 @@ const InputOfModal = ({
                       initialValue={value as MultiInputItem[][] | undefined}
                       onlyOne={field.inputConfig.onlyOne}
                       required={field.required}
+                      currentFormData={currentFormData as Record<string, unknown>}
                     />
                   );
                 }
@@ -204,6 +213,7 @@ const InputOfModal = ({
                       initialValue={value as MultiInputItem[][] | undefined}
                       onlyOne={field.inputConfig.onlyOne}
                       required={field.required}
+                      currentFormData={currentFormData as Record<string, unknown>}
                     />
                   );
                 }

--- a/src/services/config/teamProfileConfig.ts
+++ b/src/services/config/teamProfileConfig.ts
@@ -174,26 +174,46 @@ export const teamProfileConfig: FormConfig = {
       dropdownInputConfig: {
         nameColumnName: 'profile_name',
         valueColumnName: 'profile_id',
-        query: async () => {
+        query: async (formData) => {
           const supabase = await createClient();
 
-          // 팀 owner 목록 조회
-          const { data: teams } = await supabase
+          // 현재 로그인한 사용자 조회
+          const { data: { user } } = await supabase.auth.getUser();
+
+          if (!user) {
+            console.error('User not authenticated');
+            return [];
+          }
+
+          let ownerStudentId: string;
+
+          // mode에 따라 owner 결정
+          if (formData?._mode === 'create') {
+            // 생성 모드: 현재 로그인한 유저가 owner
+            ownerStudentId = user.id;
+          } else {
+            // 수정 모드: formData에서 owner 추출 (없으면 현재 유저 사용)
+            ownerStudentId = (formData?.owner as string) || user.id;
+          }
+
+          // owner의 profile_id 조회
+          const { data: ownerProfile } = await supabase
             .from('profile')
-            .select('owner')
-            .eq('is_team', true)
-            .not('owner', 'is', null);
+            .select('profile_id')
+            .eq('owner', ownerStudentId)
+            .eq('is_team', false)
+            .maybeSingle();
 
-          const ownerIds = (teams as { owner: string }[] | null)?.map((team) => team.owner) ?? [];
+          const ownerProfileId = (ownerProfile as { profile_id?: string } | null)?.profile_id;
 
-          // owner가 아닌 개인 프로필만 DB에서 필터링하여 조회
+          // owner를 제외한 모든 개인 프로필 조회
           let query = supabase
             .from('profile')
             .select('profile_id, profile_name')
             .eq('is_team', false);
 
-          if (ownerIds.length > 0) {
-            query = query.not('profile_id', 'in', `(${ownerIds.join(',')})`);
+          if (ownerProfileId) {
+            query = query.neq('profile_id', ownerProfileId);
           }
 
           const { data, error } = await query;

--- a/src/services/config/teamProfileConfig.ts
+++ b/src/services/config/teamProfileConfig.ts
@@ -176,15 +176,30 @@ export const teamProfileConfig: FormConfig = {
         valueColumnName: 'profile_id',
         query: async () => {
           const supabase = await createClient();
+
+          const { data: teams } = await supabase
+            .from('profile')
+            .select('owner')
+            .eq('is_team', true)
+            .not('owner', 'is', null);
+
+          const ownerIds = new Set(
+            teams?.map((team: { owner: string | null }) => team.owner).filter(Boolean) ?? []
+          );
+
           const { data, error } = await supabase
             .from('profile')
             .select('profile_id, profile_name')
             .eq('is_team', false);
+
           if (error) {
             console.error('Error fetching data:', error);
             return [];
           }
-          return data || [];
+
+          return data?.filter((profile: { profile_id: string; profile_name: string }) =>
+            !ownerIds.has(profile.profile_id)
+          ) ?? [];
         },
       },
       columnInfo: { table: 'team_member', column: '*' },

--- a/src/services/config/teamProfileConfig.ts
+++ b/src/services/config/teamProfileConfig.ts
@@ -283,13 +283,27 @@ export const teamProfileConfig: FormConfig = {
       }
     }
 
-    // GraphQL 처리
-    await processGraphQLRelationTables(
-      graphqlTables,
-      profileId,
-      'profile_id',
-      originalRelationData,
-    );
+    // GraphQL 처리 - team_member를 먼저 처리 (RLS 정책 때문)
+    const teamMemberTable = graphqlTables.find(t => t.tableName === 'team_member');
+    const otherTables = graphqlTables.filter(t => t.tableName !== 'team_member');
+
+    if (teamMemberTable) {
+      await processGraphQLRelationTables(
+        [teamMemberTable],
+        profileId,
+        'profile_id',
+        originalRelationData,
+      );
+    }
+
+    if (otherTables.length > 0) {
+      await processGraphQLRelationTables(
+        otherTables,
+        profileId,
+        'profile_id',
+        originalRelationData,
+      );
+    }
 
     console.log('[teamProfileConfig] afterSave completed');
   },

--- a/src/services/config/teamProfileConfig.ts
+++ b/src/services/config/teamProfileConfig.ts
@@ -177,29 +177,33 @@ export const teamProfileConfig: FormConfig = {
         query: async () => {
           const supabase = await createClient();
 
+          // 팀 owner 목록 조회
           const { data: teams } = await supabase
             .from('profile')
             .select('owner')
             .eq('is_team', true)
             .not('owner', 'is', null);
 
-          const ownerIds = new Set(
-            teams?.map((team: { owner: string | null }) => team.owner).filter(Boolean) ?? []
-          );
+          const ownerIds = (teams as { owner: string }[] | null)?.map((team) => team.owner) ?? [];
 
-          const { data, error } = await supabase
+          // owner가 아닌 개인 프로필만 DB에서 필터링하여 조회
+          let query = supabase
             .from('profile')
             .select('profile_id, profile_name')
             .eq('is_team', false);
 
+          if (ownerIds.length > 0) {
+            query = query.not('profile_id', 'in', `(${ownerIds.join(',')})`);
+          }
+
+          const { data, error } = await query;
+
           if (error) {
-            console.error('Error fetching data:', error);
+            console.error('Error fetching profiles:', error);
             return [];
           }
 
-          return data?.filter((profile: { profile_id: string; profile_name: string }) =>
-            !ownerIds.has(profile.profile_id)
-          ) ?? [];
+          return data ?? [];
         },
       },
       columnInfo: { table: 'team_member', column: '*' },

--- a/src/services/core/dataService.graphql.client.ts
+++ b/src/services/core/dataService.graphql.client.ts
@@ -487,12 +487,39 @@ export class GraphQLDataService {
     response: unknown,
     variables?: Record<string, unknown>,
   ): string | number | null {
-    // 먼저 캐시된 profile_id가 있으면 사용
-    if (this.currentProfileId) {
-      return this.currentProfileId;
+    // 응답 객체에서 ID 찾기 (생성/업데이트 모두 응답 우선)
+    const resp = response as Record<string, unknown> | undefined;
+    if (resp) {
+      // updateXXXCollection 또는 insertIntoXXXCollection 패턴의 키 찾기
+      const mutationKey = Object.keys(resp).find(
+        (key) =>
+          (key.startsWith('update') || key.startsWith('insertInto')) &&
+          key.endsWith('Collection'),
+      );
+
+      if (mutationKey) {
+        const collection = resp[mutationKey] as
+          | {
+              records?: Array<Record<string, unknown>>;
+            }
+          | undefined;
+
+        if (collection?.records && collection.records.length > 0) {
+          const record = collection.records[0];
+          // profile_id, project_id 등 다양한 ID 필드 지원
+          const extractedId = (record.profile_id || record.project_id || record.id || null) as
+            | string
+            | number
+            | null;
+
+          if (extractedId) {
+            return extractedId;
+          }
+        }
+      }
     }
 
-    // variables에서 project_id 확인
+    // 응답에서 못 찾았으면 variables에서 확인
     if (variables?.project_id) {
       return variables.project_id as string | number;
     }
@@ -502,30 +529,9 @@ export class GraphQLDataService {
       return variables.owner as string | number;
     }
 
-    // 응답 객체에서 ID 찾기
-    const resp = response as Record<string, unknown> | undefined;
-    if (!resp) return null;
-
-    // updateXXXCollection 패턴의 키 찾기
-    const updateKey = Object.keys(resp).find(
-      (key) => key.startsWith('update') && key.endsWith('Collection'),
-    );
-
-    if (updateKey) {
-      const collection = resp[updateKey] as
-        | {
-            records?: Array<Record<string, unknown>>;
-          }
-        | undefined;
-
-      if (collection?.records && collection.records.length > 0) {
-        const record = collection.records[0];
-        // profile_id, project_id 등 다양한 ID 필드 지원
-        return (record.profile_id || record.project_id || record.id || null) as
-          | string
-          | number
-          | null;
-      }
+    // 마지막으로 캐시된 profile_id 사용 (업데이트 시)
+    if (this.currentProfileId) {
+      return this.currentProfileId;
     }
 
     return null;

--- a/src/services/core/dataService.graphql.client.ts
+++ b/src/services/core/dataService.graphql.client.ts
@@ -289,8 +289,8 @@ export class GraphQLDataService {
 
       console.log('Save Data - Response:', JSON.stringify(response, null, 2));
 
-      // 관계 테이블 데이터 처리 (Update 시에만)
-      if (isUpdate && relationTableData.size > 0) {
+      // 관계 테이블 데이터 처리 (Create 또는 Update 시)
+      if (relationTableData.size > 0) {
         console.log('Processing relation tables...');
 
         // FormConfig의 afterSave 콜백이 있으면 호출

--- a/src/services/graphQL/relationTableHelper.graphql.ts
+++ b/src/services/graphQL/relationTableHelper.graphql.ts
@@ -607,6 +607,11 @@ export async function processGraphQLRelationTables(
     return;
   }
 
+  // identifier를 적절한 타입으로 변환 (project_id는 숫자여야 함)
+  const typedIdentifier = identifierField === 'project_id'
+    ? Number(identifier)
+    : identifier;
+
   // Mutation 생성
   processedTables.forEach(({ tableName, changes }, index) => {
     const tableConfig = graphqlTables.find((t) => t.tableName === tableName);
@@ -619,7 +624,7 @@ export async function processGraphQLRelationTables(
         const deleteVarName = `${tableName}DeleteFilter${index}_${itemIndex}`;
         mutationBlock += `$${deleteVarName}: ${tableName}Filter!, `;
 
-        const deleteFilter = deleteFilterGen(item, identifier, identifierField);
+        const deleteFilter = deleteFilterGen(item, typedIdentifier, identifierField);
 
         mutationVariables[deleteVarName] = deleteFilter;
 
@@ -636,9 +641,10 @@ export async function processGraphQLRelationTables(
     if (changes.toInsert.length > 0) {
       const insertVarName = `${tableName}InsertObjects${index}`;
       mutationBlock += `$${insertVarName}: [${tableName}InsertInput!]!, `;
+
       mutationVariables[insertVarName] = changes.toInsert.map((item) => ({
         ...item,
-        [identifierField]: identifier,
+        [identifierField]: typedIdentifier,
       }));
 
       const insertFieldName = `insert${


### PR DESCRIPTION
## 💡 개요

팀 프로필 생성 및 수정 시 발생하는 여러 오류를 수정했습니다. RLS 정책 위반으로 인한 생성 실패, GraphQL 타입 불일치 오류, 레코드 ID 추출 오류, 그리고 팀원 선택 시 팀 owner가 중복
표시되는 문제를 해결했습니다.

## 📃 작업내용

1. 팀 프로필 생성 시 RLS 정책 준수
```mermaid
graph TD
    A[팀 프로필 저장] --> B{관계 테이블 구분}
    B --> C[team_member 우선 삽입]
    C --> D[profile_link 등 나머지 삽입]
    D --> E[완료]

    style C fill:#90EE90
    style D fill:#87CEEB
```
문제: profile_link RLS 정책이 team_member 테이블을 참조하는데, 동시 삽입 시 RLS 정책 위반 발생
해결: teamProfileConfig.ts에서 team_member를 먼저 처리 후 다른 테이블 처리

2. GraphQL 타입 오류 수정

문제: project_id가 문자열로 전달되어 GraphQL Int 타입과 불일치
해결: relationTableHelper.graphql.ts에서 project_id를 Int 타입으로 명시적 변환

3. 레코드 ID 추출 로직 개선

문제: 캐시된 profile_id를 우선 참조하여 새로 생성된 레코드 ID를 정확히 추출하지 못함
해결: dataService.graphql.client.ts에서 응답 → variables → 캐시 순으로 우선순위 변경

4. 팀원 드롭다운 필터링
```mermaid
graph LR
    A[팀원 선택 드롭다운] --> B[모든 팀의 owner 조회]
    B --> C[is_team=false인 프로필 조회]
    C --> D[owner 제외 필터링]
    D --> E[드롭다운 표시]

    style D fill:#FFB6C1
```
문제: 팀원 드롭다운에서 이미 다른 팀의 owner로 등록된 사용자가 옵션으로 표시됨
해결: teamProfileConfig.ts의 query에서 모든 팀의 owner를 조회 후 제외

5. 모달 기능 개선

문제: ProjectEditModal에서 모달 닫기 기능 부재
해결: onClose prop 추가

## 🔀 변경사항

- 브랜치 이름은 "스킬태그-기여자-수정-추가-불가-오류-수정"이지만, 실제로는 팀 프로필 생성/수정 관련 오류 수정에 집중
- 5개의 독립적인 버그 수정이 포함됨 (RLS 정책, GraphQL 타입, ID 추출, 드롭다운 필터링, 모달 기능)

## 📸 스크린샷
