### PR TITLE
(i25 338) feat/특정 수상이력 두번 연속 보임

### DIFF
--- a/src/app/components/feature/auth/SupabaseSessionSync.tsx
+++ b/src/app/components/feature/auth/SupabaseSessionSync.tsx
@@ -79,7 +79,7 @@ export default function SupabaseSessionSync() {
           error &&
           typeof error === 'object' &&
           'code' in error &&
-          (error as any).code === 'refresh_token_already_used'
+          (error as { code?: string }).code === 'refresh_token_already_used'
         ) {
           const storageKey = process.env.NEXT_PUBLIC_SUPABASE_STORAGE_KEY || 'sb-bsmhubsp-auth-token';
           localStorage.removeItem(storageKey);

--- a/src/app/components/layout/header/HeaderDropdown.tsx
+++ b/src/app/components/layout/header/HeaderDropdown.tsx
@@ -7,10 +7,7 @@ import { useModal } from '@/app/components/modal';
 import { useCurrentUser } from '@/utils/hook/useCurrentUser';
 import { openProjectModal } from '@/utils/modal/openProjectModal';
 import { openTeamModal } from '@/utils/modal/openTeamModal';
-import {
-  checkProfileExistence,
-  getProfileByStudentId,
-} from '@/services/profile/getProfileApi.client';
+import { getProfileByStudentId } from '@/services/profile/getProfileApi.client';
 
 const HeaderDropdown = () => {
   const currentUser = useCurrentUser();
@@ -32,10 +29,7 @@ const HeaderDropdown = () => {
     let mounted = true;
 
     const init = async () => {
-      const [profile, exists] = await Promise.all([
-        getProfileByStudentId(currentUser.id),
-        checkProfileExistence(currentUser.id),
-      ]);
+      const profile = await getProfileByStudentId(currentUser.id);
 
       if (!mounted) return;
       if (profile) {

--- a/src/app/components/modal/inputs/SingleInput.tsx
+++ b/src/app/components/modal/inputs/SingleInput.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import { StandardInputProps } from './types/inputTypes';
 
 const Inputs = ({
@@ -19,17 +19,17 @@ const Inputs = ({
   const stringValue = typeof value === 'string' ? value : value?.toString() || '';
 
   // textarea 높이 자동 조정 함수
-  const adjustHeight = () => {
+  const adjustHeight = useCallback(() => {
     if (textarea && textareaRef.current) {
       textareaRef.current.style.height = 'auto';
       textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
     }
-  };
+  }, [textarea]);
 
   // value 변경 시 높이 조정
   useEffect(() => {
     adjustHeight();
-  }, [textarea, stringValue, adjustHeight]);
+  }, [stringValue, adjustHeight]);
 
   // 포커스 처리
   useEffect(() => {

--- a/src/services/config/profileConfig.ts
+++ b/src/services/config/profileConfig.ts
@@ -70,6 +70,9 @@ export const profileConfig: FormConfig = {
                   node {
                     competition_id
                     prize
+                    competitions {
+                      competition_name
+                    }
                   }
                 }
               }
@@ -280,9 +283,15 @@ export const profileConfig: FormConfig = {
         onlyOne: false,
         inputs: [
           {
+            name: 'competitions.competition_name',
+            type: 'text',
+            placeholder: '대회이름을 입력하세요',
+            required: true,
+          },
+          {
             name: 'prize',
             type: 'text',
-            placeholder: '수상내역을 입력하세요',
+            placeholder: '상명을 입력하세요',
             required: true,
           },
         ],

--- a/src/services/graphQL/relationTableHelper.graphql.ts
+++ b/src/services/graphQL/relationTableHelper.graphql.ts
@@ -79,19 +79,18 @@ export async function getOrCreateCertificateIds(
 }
 
 /**
- * prize를 competition_id로 변환 (없으면 생성)
+ * competition_name을 competition_id로 변환 (없으면 생성)
  */
 export async function getOrCreateCompetitionIds(
-  prizes: string[],
+  competitionNames: string[],
 ): Promise<number[]> {
-  if (prizes.length === 0) return [];
+  if (competitionNames.length === 0) return [];
 
   const supabase = createClient();
   const competitionIds: number[] = [];
 
-  for (const prize of prizes) {
-    // 간단한 대회명 생성 (실제로는 더 정교한 로직이 필요할 수 있음)
-    const competitionName = `대회 - ${prize}`;
+  for (const competitionName of competitionNames) {
+    if (!competitionName || competitionName.trim() === '') continue;
 
     const { data: existingCompetition } = await supabase
       .from('competitions')
@@ -262,25 +261,42 @@ export async function updateStudentCertificates(
 /**
  * profile_competitions 테이블 업데이트 (개별 삭제 + upsert)
  * @param profileId - 프로필 ID
- * @param prizes - 새로운 수상 이력 배열
- * @param existingComps - 기존 수상 이력 데이터 배열 (캐시된 데이터, competition_id 포함)
+ * @param competitions - 새로운 수상 이력 배열 (competition_name, prize 포함)
+ * @param existingComps - 기존 수상 이력 데이터 배열 (캐시된 데이터, competition_id, prize 포함)
  */
 export async function updateProfileCompetitions(
   profileId: string,
-  prizes: string[],
-  existingComps: Array<{ competition_id: number; prize: string }> = [],
+  competitions: Array<{ competition_name: string; prize: string }>,
+  existingComps: Array<{
+    competition_id: number;
+    prize: string;
+    competitions?: { competition_name: string };
+  }> = [],
 ): Promise<void> {
   const supabase = createClient();
 
-  const existingPrizes = new Set(existingComps.map((c) => c.prize));
-  const newPrizes = new Set(prizes);
-
-  // 2. 삭제할 항목 찾기
-  const compsToDelete = existingComps.filter(
-    (comp) => !newPrizes.has(comp.prize),
+  // 기존 데이터를 competition_name과 prize 조합으로 비교하기 위한 Set 생성
+  const existingKeys = new Set(
+    existingComps.map(
+      (c) =>
+        `${c.competitions?.competition_name || ''}|${c.prize}`,
+    ),
   );
 
-  // 3. 개별 삭제 - competition_id를 이미 알고 있음
+  // 새로운 데이터를 competition_name과 prize 조합으로 비교하기 위한 Set 생성
+  const newKeys = new Set(
+    competitions.map((c) => `${c.competition_name}|${c.prize}`),
+  );
+
+  // 삭제할 항목 찾기 (기존에 있지만 새로운 데이터에 없는 것)
+  const compsToDelete = existingComps.filter(
+    (comp) =>
+      !newKeys.has(
+        `${comp.competitions?.competition_name || ''}|${comp.prize}`,
+      ),
+  );
+
+  // 개별 삭제 - competition_id를 이미 알고 있음
   for (const comp of compsToDelete) {
     await supabase
       .from('profile_competitions')
@@ -289,16 +305,20 @@ export async function updateProfileCompetitions(
       .eq('competition_id', comp.competition_id);
   }
 
-  // 4. 추가할 항목 찾기
-  const prizesToAdd = prizes.filter((prize) => !existingPrizes.has(prize));
+  // 추가할 항목 찾기 (새로운 데이터에 있지만 기존에 없는 것)
+  const competitionsToAdd = competitions.filter(
+    (comp) =>
+      !existingKeys.has(`${comp.competition_name}|${comp.prize}`),
+  );
 
-  // 5. 새 항목 삽입
-  if (prizesToAdd.length > 0) {
-    const competitionIds = await getOrCreateCompetitionIds(prizesToAdd);
+  // 새 항목 삽입
+  if (competitionsToAdd.length > 0) {
+    const competitionNames = competitionsToAdd.map((c) => c.competition_name);
+    const competitionIds = await getOrCreateCompetitionIds(competitionNames);
     if (competitionIds.length > 0) {
       const compPayloads = competitionIds.map((compId, index) => ({
         competition_id: compId,
-        prize: prizesToAdd[index],
+        prize: competitionsToAdd[index].prize,
         profile_id: profileId,
       }));
       await supabase.from('profile_competitions').insert(compPayloads as never);
@@ -506,9 +526,22 @@ export async function processRestRelationTables(
             .filter(Boolean);
           break;
         case 'profile_competitions':
-          processedData = (relationData as Array<{ prize: string }>)
-            .map((item) => item.prize)
-            .filter(Boolean);
+          processedData = (
+            relationData as Array<{
+              prize: string;
+              competitions?: { competition_name: string };
+            }>
+          )
+            .map((item) => ({
+              competition_name:
+                item.competitions?.competition_name || '',
+              prize: item.prize || '',
+            }))
+            .filter(
+              (item) =>
+                item.competition_name.trim() !== '' &&
+                item.prize.trim() !== '',
+            );
           break;
         case 'student_jobs':
           // 단일 선택이므로 job_id 배열 추출

--- a/src/services/supabase/middleware.server.ts
+++ b/src/services/supabase/middleware.server.ts
@@ -50,7 +50,7 @@ export async function updateSession(request: NextRequest) {
       error &&
       typeof error === 'object' &&
       'code' in error &&
-      (error as any).code === 'refresh_token_already_used'
+      (error as { code?: string }).code === 'refresh_token_already_used'
     ) {
       // Clear all cookies
       const cookies = request.cookies.getAll();

--- a/src/utils/project/sortProjects.ts
+++ b/src/utils/project/sortProjects.ts
@@ -1,4 +1,3 @@
-import { CardProps } from '@/app/components/card/project/ProjectCard';
 import { ProjectData } from '@/services/project/getProjects.server';
 import {
   calculateGradeFromJoinAt,


### PR DESCRIPTION
# [I25-338] 수상이력 멀티인풋 구현 및 빌드 오류 수정

## 💡 개요

프로필 모달의 수상이력 필드를 개선하여 대회이름과 상명을 별도로 입력받을 수 있도록 멀티인풋으로 변경했습니다. 기존에는 상명(`prize`)만 입력받았으나, 이제 대회이름(`competition_name`)과 상명을 분리하여 더 정확한 정보를 저장할 수 있습니다.

또한 빌드 오류를 수정하여 프로젝트가 정상적으로 컴파일되도록 개선했습니다.

## 📃 작업내용

### 1. 수상이력 멀티인풋 구현

수상이력 필드를 단일 입력에서 대회이름과 상명을 입력받는 멀티인풋으로 변경했습니다.

```mermaid
graph TD
    A[프로필 모달 열기] --> B[GraphQL 쿼리 실행]
    B --> C[profile_competitionsCollection 조회]
    C --> D[competitions.competition_name 포함]
    D --> E[MultiInput 렌더링]
    E --> F[대회이름 입력]
    E --> G[상명 입력]
    F --> H[formData 저장]
    G --> H
    H --> I[updateProfileCompetitions 호출]
    I --> J[competition_name으로 competition_id 조회/생성]
    J --> K[profile_competitions 테이블 업데이트]
```

### 2. 주요 구현 내용

1. **profileConfig.ts 수정**
   - `profile_competitions` 필드의 `inputConfig.inputs`에 두 개의 입력 필드 추가
     - `competitions.competition_name`: 대회이름 입력 필드
     - `prize`: 상명 입력 필드
   - GraphQL read 쿼리에 `competitions { competition_name }` 조회 추가

2. **relationTableHelper.graphql.ts 수정**
   - `getOrCreateCompetitionIds` 함수 수정
     - `prizes: string[]` → `competitionNames: string[]`로 변경
     - `prize` 기반 자동 생성 로직 제거, `competition_name` 직접 사용
   - `updateProfileCompetitions` 함수 시그니처 변경
     - `prizes: string[]` → `competitions: Array<{ competition_name: string; prize: string }>`
     - `competition_name`과 `prize` 조합으로 비교하여 삭제/추가 로직 개선
   - `processRestRelationTables`의 기본 변환 로직 수정
     - `profile_competitions` 케이스에서 `{ competition_name, prize }` 객체 배열 처리

3. **데이터 변환 로직 확인**
   - `dataTransformer.graphql.ts`의 점 표기법(`competitions.competition_name`) 처리 로직이 올바르게 동작함을 확인

### 3. 빌드 오류 수정

TypeScript 및 ESLint 오류를 수정하여 프로젝트가 정상적으로 빌드되도록 개선했습니다.

1. **타입 안정성 개선**
   - `SupabaseSessionSync.tsx`: `(error as any).code` → `(error as { code?: string }).code`
   - `middleware.server.ts`: `(error as any).code` → `(error as { code?: string }).code`

2. **사용되지 않는 코드 제거**
   - `HeaderDropdown.tsx`: 사용되지 않는 `exists` 변수 및 `checkProfileExistence` import 제거
   - `sortProjects.ts`: 사용되지 않는 `CardProps` import 제거

3. **React Hook 최적화**
   - `SingleInput.tsx`: `adjustHeight` 함수를 `useCallback`으로 감싸 의존성 경고 해결

## 🔀 변경사항

### 추가 개선사항

1. **데이터 구조 개선**
   - 기존에는 `prize`만으로 대회 정보를 추론했으나, 이제 `competition_name`과 `prize`를 명확히 분리하여 저장
   - `competitions` 테이블의 `competition_name`을 직접 사용하여 데이터 일관성 향상

2. **타입 안정성 향상**
   - `any` 타입 사용을 제거하고 정확한 타입 정의 사용
   - 에러 처리 시 타입 안정성 개선

3. **코드 품질 개선**
   - 사용되지 않는 변수 및 import 제거
   - React Hook 의존성 경고 해결

## 주요 파일 변경

- `src/services/config/profileConfig.ts`
- `src/services/graphQL/relationTableHelper.graphql.ts`
- `src/app/components/feature/auth/SupabaseSessionSync.tsx`
- `src/app/components/layout/header/HeaderDropdown.tsx`
- `src/app/components/modal/inputs/SingleInput.tsx`
- `src/services/supabase/middleware.server.ts`
- `src/utils/project/sortProjects.ts`

## 📸 스크린샷
<img width="1392" height="404" alt="image" src="https://github.com/user-attachments/assets/e13fca15-28be-4641-9d5c-acda85463346" />
<img width="175" height="104" alt="image" src="https://github.com/user-attachments/assets/f0e10bf4-4740-4e61-8f6d-8af4e4b1d20c" />


[I25-338]: https://obtuse-t.atlassian.net/browse/I25-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ