### PR TITLE
I25 349 fix remote image

### DIFF
--- a/src/services/supabase/imageHostConverter.ts
+++ b/src/services/supabase/imageHostConverter.ts
@@ -11,7 +11,10 @@ export function convertFromDatabaseImageURL(url: string): string {
   const internalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_INTERNAL_URL?.replace(/\/$/, '') || '';
   const externalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, '') || '';
   
-  if(cleanedUrl.endsWith('.svg')) {
+  const excludedExtensions = ['.svg', '.ico', '.bmp'];
+  const isExcluded = excludedExtensions.some(ext => cleanedUrl.toLowerCase().endsWith(ext));
+
+  if(isExcluded) {
     cleanedUrl = cleanedUrl.replace('{{supabaseHost}}', externalSupabaseUrl);
   }else {
     // {{supabaseHost}}를 실제 URL로 변환

--- a/src/services/supabase/imageHostConverter.ts
+++ b/src/services/supabase/imageHostConverter.ts
@@ -14,9 +14,9 @@ export function convertFromDatabaseImageURL(url: string): string {
   const excludedExtensions = ['.svg', '.ico', '.bmp'];
   const isExcluded = excludedExtensions.some(ext => cleanedUrl.toLowerCase().endsWith(ext));
 
-  if(isExcluded) {
+  if (isExcluded) {
     cleanedUrl = cleanedUrl.replace('{{supabaseHost}}', externalSupabaseUrl);
-  }else {
+  } else {
     // {{supabaseHost}}를 실제 URL로 변환
     cleanedUrl = cleanedUrl.replace('{{supabaseHost}}', internalSupabaseUrl);
   }

--- a/src/services/supabase/imageHostConverter.ts
+++ b/src/services/supabase/imageHostConverter.ts
@@ -7,10 +7,16 @@ export function convertFromDatabaseImageURL(url: string): string {
   let cleanedUrl = url.replace(/::\w+$/, '');
   // 작은따옴표 제거 (문자열 리터럴인 경우)
   cleanedUrl = cleanedUrl.replace(/^'|'$/g, '');
+
+  const internalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_INTERNAL_URL?.replace(/\/$/, '') || '';
+  const externalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, '') || '';
   
-  // {{supabaseHost}}를 실제 URL로 변환
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_INTERNAL_URL?.replace(/\/$/, '') || '';
-  cleanedUrl = cleanedUrl.replace('{{supabaseHost}}', supabaseUrl);
+  if(cleanedUrl.endsWith('.svg')) {
+    cleanedUrl = cleanedUrl.replace('{{supabaseHost}}', externalSupabaseUrl);
+  }else {
+    // {{supabaseHost}}를 실제 URL로 변환
+    cleanedUrl = cleanedUrl.replace('{{supabaseHost}}', internalSupabaseUrl);
+  }
   
   // 이중 슬래시 제거 (http:// 또는 https:// 다음의 슬래시는 제외)
   cleanedUrl = cleanedUrl.replace(/([^:]\/)\/+/g, '$1');


### PR DESCRIPTION
## 💡 개요
Next.js Image Optimization에서 지원하지 않거나 비효율적인 이미지 형식(SVG, ICO, BMP)을 최적화 대상에서 제외하고 원본 URL을 사용하도록 수정했습니다.
## 📃 작업내용
- [src/services/supabase/imageHostConverter.ts](cci:7://file:///Users/obtuse/gitRepos/bsmhub/src/services/supabase/imageHostConverter.ts:0:0-0:0) 파일 수정
- `.svg`, `.ico`, `.bmp` 확장자를 가진 이미지는 `externalSupabaseUrl`을 반환하도록 로직 변경
- 확장자 체크 시 대소문자 구분 없애기 (`toLowerCase()` 적용)
## 🔀 변경사항
- 기존: `.svg` 확장자만 대소문자 구분하여 제외
- 변경: `.svg`, `.ico`, `.bmp` 확장자를 대소문자 구분 없이 제외
## 📸 스크린샷
(해당 없음)
