### PR TITLE
[I25-378] fix: Figma URL 처리 개선

### DIFF
--- a/src/app/components/tiptap/tiptap-node/figma-node/figma-node-extension.ts
+++ b/src/app/components/tiptap/tiptap-node/figma-node/figma-node-extension.ts
@@ -1,6 +1,7 @@
 import { mergeAttributes, Node } from "@tiptap/react"
 import { ReactNodeViewRenderer } from "@tiptap/react"
 import { FigmaNode as FigmaNodeComponent } from "@/app/components/tiptap/tiptap-node/figma-node/figma-node"
+import { getFigmaEmbedUrl } from "@/app/components/tiptap/tiptap-node/figma-node/figma-utils"
 
 export interface FigmaNodeOptions {
   /**
@@ -19,31 +20,6 @@ declare module "@tiptap/react" {
       setFigma: (options: { url: string }) => ReturnType
     }
   }
-}
-
-/**
- * Convert Figma URL to embed URL using www.figma.com/embed format
- */
-function getFigmaEmbedUrl(url: string): string {
-  // Validate the URL first
-  try {
-    const urlObj = new URL(url)
-    const allowedHosts = ["figma.com", "www.figma.com", "embed.figma.com"]
-    if (!allowedHosts.includes(urlObj.hostname)) {
-      return url // Return original URL if not a Figma URL
-    }
-    
-    // If it's already an embed URL, return it as-is to avoid double encoding
-    if (urlObj.hostname === "embed.figma.com" || urlObj.pathname.startsWith("/embed")) {
-      return url
-    }
-  } catch {
-    // Invalid URL, return as-is
-    return url
-  }
-  
-  // Use Figma's standard embed format: encode the full original URL
-  return `https://www.figma.com/embed?embed_host=share&url=${encodeURIComponent(url)}`
 }
 
 /**
@@ -80,6 +56,20 @@ export const FigmaNode = Node.create<FigmaNodeOptions>({
           }
           return {
             "data-url": attributes.url,
+          }
+        },
+      },
+      originalUrl: {
+        default: null,
+        parseHTML: (element) => {
+          return element.getAttribute("data-original-url")
+        },
+        renderHTML: (attributes) => {
+          if (!attributes.originalUrl) {
+            return {}
+          }
+          return {
+            "data-original-url": attributes.originalUrl,
           }
         },
       },
@@ -154,6 +144,7 @@ export const FigmaNode = Node.create<FigmaNodeOptions>({
             type: this.name,
             attrs: {
               url: embedUrl,
+              originalUrl: options.url,
             },
           })
         },

--- a/src/app/components/tiptap/tiptap-node/figma-node/figma-node-extension.ts
+++ b/src/app/components/tiptap/tiptap-node/figma-node/figma-node-extension.ts
@@ -22,38 +22,28 @@ declare module "@tiptap/react" {
 }
 
 /**
- * Extract Figma file ID from URL
- */
-function extractFigmaFileId(url: string): string | null {
-  // Match patterns like:
-  // https://www.figma.com/file/{fileId}/...
-  // https://www.figma.com/design/{fileId}/...
-  // https://figma.com/file/{fileId}/...
-  const patterns = [
-    /figma\.com\/(?:file|design)\/([a-zA-Z0-9]+)/,
-    /figma\.com\/file\/([a-zA-Z0-9]+)/,
-  ]
-
-  for (const pattern of patterns) {
-    const match = url.match(pattern)
-    if (match && match[1]) {
-      return match[1]
-    }
-  }
-
-  return null
-}
-
-/**
- * Convert Figma URL to embed URL
+ * Convert Figma URL to embed URL using www.figma.com/embed format
  */
 function getFigmaEmbedUrl(url: string): string {
-  const fileId = extractFigmaFileId(url)
-  if (fileId) {
-    return `https://www.figma.com/embed?embed_host=share&url=https://www.figma.com/file/${fileId}`
+  // Validate the URL first
+  try {
+    const urlObj = new URL(url)
+    const allowedHosts = ["figma.com", "www.figma.com", "embed.figma.com"]
+    if (!allowedHosts.includes(urlObj.hostname)) {
+      return url // Return original URL if not a Figma URL
+    }
+    
+    // If it's already an embed URL, return it as-is to avoid double encoding
+    if (urlObj.hostname === "embed.figma.com" || urlObj.pathname.startsWith("/embed")) {
+      return url
+    }
+  } catch {
+    // Invalid URL, return as-is
+    return url
   }
-  // If we can't extract the file ID, try to use the URL as-is
-  return url
+  
+  // Use Figma's standard embed format: encode the full original URL
+  return `https://www.figma.com/embed?embed_host=share&url=${encodeURIComponent(url)}`
 }
 
 /**

--- a/src/app/components/tiptap/tiptap-node/figma-node/figma-node.tsx
+++ b/src/app/components/tiptap/tiptap-node/figma-node/figma-node.tsx
@@ -7,37 +7,26 @@ import { Button } from "@/app/components/tiptap/tiptap-ui-primitive/button"
 import { Input } from "@/app/components/tiptap/tiptap-ui-primitive/input"
 import { CloseIcon } from "@/app/components/tiptap/tiptap-icons/close-icon"
 import { ExternalLinkIcon } from "@/app/components/tiptap/tiptap-icons/external-link-icon"
+import {
+  getFigmaEmbedUrl,
+  extractOriginalUrlFromEmbed,
+} from "@/app/components/tiptap/tiptap-node/figma-node/figma-utils"
 import "@/app/components/tiptap/tiptap-node/figma-node/figma-node.scss"
 
-/**
- * Convert Figma URL to embed URL using www.figma.com/embed format
- */
-function getFigmaEmbedUrl(url: string): string {
-  // Validate the URL first
-  try {
-    const urlObj = new URL(url)
-    const allowedHosts = ["figma.com", "www.figma.com", "embed.figma.com"]
-    if (!allowedHosts.includes(urlObj.hostname)) {
-      return ""
-    }
-    
-    // If it's already an embed URL, return it as-is to avoid double encoding
-    if (urlObj.hostname === "embed.figma.com" || urlObj.pathname.startsWith("/embed")) {
-      return url
-    }
-  } catch {
-    // Invalid URL
-    return ""
-  }
-  
-  // Use Figma's standard embed format: encode the full original URL
-  const embedUrl = `https://www.figma.com/embed?embed_host=share&url=${encodeURIComponent(url)}`
-  return embedUrl
-}
-
 export const FigmaNode: React.FC<NodeViewProps> = (props) => {
-  const { url: initialUrl } = props.node.attrs
-  const [url, setUrl] = useState(initialUrl || "")
+  const { url: initialUrl, originalUrl: initialOriginalUrl } = props.node.attrs
+
+  // 원본 URL: 노드 속성에 originalUrl이 있으면 사용, 없으면 url에서 추출 시도
+  const getOriginalUrl = (urlAttr: string, origUrlAttr: string | null): string => {
+    if (origUrlAttr) return origUrlAttr
+    if (!urlAttr) return ""
+    return extractOriginalUrlFromEmbed(urlAttr)
+  }
+
+  const [originalUrl, setOriginalUrl] = useState(
+    getOriginalUrl(initialUrl, initialOriginalUrl)
+  )
+  const [inputUrl, setInputUrl] = useState(originalUrl)
   const [isEditing, setIsEditing] = useState(!initialUrl)
   const [embedUrl, setEmbedUrl] = useState(
     initialUrl ? getFigmaEmbedUrl(initialUrl) : ""
@@ -45,23 +34,27 @@ export const FigmaNode: React.FC<NodeViewProps> = (props) => {
 
   useEffect(() => {
     if (initialUrl) {
-      setUrl(initialUrl)
+      const origUrl = getOriginalUrl(initialUrl, initialOriginalUrl)
+      setOriginalUrl(origUrl)
+      setInputUrl(origUrl)
       setEmbedUrl(getFigmaEmbedUrl(initialUrl))
     }
-  }, [initialUrl])
+  }, [initialUrl, initialOriginalUrl])
 
   const handleSubmit = () => {
-    if (!url.trim()) return
+    if (!inputUrl.trim()) return
 
-    const newEmbedUrl = getFigmaEmbedUrl(url)
+    const newEmbedUrl = getFigmaEmbedUrl(inputUrl)
     setEmbedUrl(newEmbedUrl)
+    setOriginalUrl(inputUrl)
     setIsEditing(false)
 
-    // Update the node attributes
+    // 노드 속성에 원본 URL과 임베드 URL 모두 저장
     const pos = props.getPos()
     if (typeof pos === "number") {
       props.updateAttributes({
         url: newEmbedUrl,
+        originalUrl: inputUrl,
       })
     }
   }
@@ -73,7 +66,7 @@ export const FigmaNode: React.FC<NodeViewProps> = (props) => {
     }
     if (e.key === "Escape") {
       setIsEditing(false)
-      setUrl(initialUrl || "")
+      setInputUrl(originalUrl)
     }
   }
 
@@ -95,8 +88,8 @@ export const FigmaNode: React.FC<NodeViewProps> = (props) => {
           <Input
             type="text"
             placeholder="Paste Figma URL here..."
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
+            value={inputUrl}
+            onChange={(e) => setInputUrl(e.target.value)}
             onKeyDown={handleKeyDown}
             autoFocus
           />
@@ -105,7 +98,7 @@ export const FigmaNode: React.FC<NodeViewProps> = (props) => {
               type="button"
               data-style="ghost"
               onClick={handleSubmit}
-              disabled={!url.trim()}
+              disabled={!inputUrl.trim()}
             >
               Embed
             </Button>
@@ -114,7 +107,7 @@ export const FigmaNode: React.FC<NodeViewProps> = (props) => {
               data-style="ghost"
               onClick={() => {
                 setIsEditing(false)
-                setUrl(initialUrl || "")
+                setInputUrl(originalUrl)
               }}
             >
               Cancel
@@ -137,11 +130,11 @@ export const FigmaNode: React.FC<NodeViewProps> = (props) => {
           >
             Edit
           </Button>
-          {url && (
+          {originalUrl && (
             <Button
               type="button"
               data-style="ghost"
-              onClick={() => window.open(url, "_blank")}
+              onClick={() => window.open(originalUrl, "_blank", "noopener,noreferrer")}
               tooltip="Open in Figma"
             >
               <ExternalLinkIcon className="tiptap-button-icon" />

--- a/src/app/components/tiptap/tiptap-node/figma-node/figma-node.tsx
+++ b/src/app/components/tiptap/tiptap-node/figma-node/figma-node.tsx
@@ -10,55 +10,29 @@ import { ExternalLinkIcon } from "@/app/components/tiptap/tiptap-icons/external-
 import "@/app/components/tiptap/tiptap-node/figma-node/figma-node.scss"
 
 /**
- * Parse Figma URL to extract type and file key
- */
-function parseFigmaUrl(url: string): { type: string; fileKey: string } | null {
-  const regex = /figma\.com\/(design|board|proto|slides|deck|file)\/([a-zA-Z0-9]+)/
-  const match = url.match(regex)
-  
-  if (match && match[1] && match[2]) {
-    // Normalize 'file' to 'design'
-    const type = match[1] === 'file' ? 'design' : match[1]
-    return {
-      type,
-      fileKey: match[2]
-    }
-  }
-  
-  return null
-}
-
-/**
- * Convert Figma URL to embed URL
+ * Convert Figma URL to embed URL using www.figma.com/embed format
  */
 function getFigmaEmbedUrl(url: string): string {
   // Validate the URL first
   try {
     const urlObj = new URL(url)
-    const allowedHosts = ["figma.com", "www.figma.com"]
+    const allowedHosts = ["figma.com", "www.figma.com", "embed.figma.com"]
     if (!allowedHosts.includes(urlObj.hostname)) {
       return ""
+    }
+    
+    // If it's already an embed URL, return it as-is to avoid double encoding
+    if (urlObj.hostname === "embed.figma.com" || urlObj.pathname.startsWith("/embed")) {
+      return url
     }
   } catch {
     // Invalid URL
     return ""
   }
   
-  const parsed = parseFigmaUrl(url)
-  if (!parsed) {
-    return ""
-  }
-  
-  const { type, fileKey } = parsed
-  const params = new URLSearchParams({
-    'embed-host': 'bsmhub',
-    'page-selector': 'true',
-    'viewport-controls': 'true',
-    'footer': 'true',
-    'theme': 'system'
-  })
-  
-  return `https://embed.figma.com/${type}/${fileKey}?${params.toString()}`
+  // Use Figma's standard embed format: encode the full original URL
+  const embedUrl = `https://www.figma.com/embed?embed_host=share&url=${encodeURIComponent(url)}`
+  return embedUrl
 }
 
 export const FigmaNode: React.FC<NodeViewProps> = (props) => {

--- a/src/app/components/tiptap/tiptap-node/figma-node/figma-node.tsx
+++ b/src/app/components/tiptap/tiptap-node/figma-node/figma-node.tsx
@@ -10,6 +10,8 @@ import { ExternalLinkIcon } from "@/app/components/tiptap/tiptap-icons/external-
 import {
   getFigmaEmbedUrl,
   extractOriginalUrlFromEmbed,
+  isValidFigmaUrl,
+  getSafeEmbedUrl,
 } from "@/app/components/tiptap/tiptap-node/figma-node/figma-utils"
 import "@/app/components/tiptap/tiptap-node/figma-node/figma-node.scss"
 
@@ -17,10 +19,18 @@ export const FigmaNode: React.FC<NodeViewProps> = (props) => {
   const { url: initialUrl, originalUrl: initialOriginalUrl } = props.node.attrs
 
   // 원본 URL: 노드 속성에 originalUrl이 있으면 사용, 없으면 url에서 추출 시도
+  // 보안을 위해 유효성 검사 수행
   const getOriginalUrl = (urlAttr: string, origUrlAttr: string | null): string => {
-    if (origUrlAttr) return origUrlAttr
+    if (origUrlAttr && isValidFigmaUrl(origUrlAttr)) return origUrlAttr
     if (!urlAttr) return ""
     return extractOriginalUrlFromEmbed(urlAttr)
+  }
+
+  // 안전한 URL만 외부 창에서 열기 위한 핸들러
+  const handleOpenInFigma = () => {
+    if (originalUrl && isValidFigmaUrl(originalUrl)) {
+      window.open(originalUrl, "_blank", "noopener,noreferrer")
+    }
   }
 
   const [originalUrl, setOriginalUrl] = useState(
@@ -125,6 +135,9 @@ export const FigmaNode: React.FC<NodeViewProps> = (props) => {
     )
   }
 
+  // 렌더링에 사용할 안전한 임베드 URL
+  const safeEmbedUrl = getSafeEmbedUrl(embedUrl)
+
   return (
     <NodeViewWrapper className="tiptap-figma-node" data-drag-handle>
       <div className="tiptap-figma-node-container">
@@ -137,11 +150,11 @@ export const FigmaNode: React.FC<NodeViewProps> = (props) => {
           >
             Edit
           </Button>
-          {originalUrl && (
+          {originalUrl && isValidFigmaUrl(originalUrl) && (
             <Button
               type="button"
               data-style="ghost"
-              onClick={() => window.open(originalUrl, "_blank", "noopener,noreferrer")}
+              onClick={handleOpenInFigma}
               tooltip="Open in Figma"
             >
               <ExternalLinkIcon className="tiptap-button-icon" />
@@ -156,10 +169,10 @@ export const FigmaNode: React.FC<NodeViewProps> = (props) => {
             <CloseIcon className="tiptap-button-icon" />
           </Button>
         </div>
-        {embedUrl ? (
+        {safeEmbedUrl ? (
           <div className="tiptap-figma-node-embed">
             <iframe
-              src={embedUrl}
+              src={safeEmbedUrl}
               width="100%"
               height="450"
               frameBorder="0"

--- a/src/app/components/tiptap/tiptap-node/figma-node/figma-node.tsx
+++ b/src/app/components/tiptap/tiptap-node/figma-node/figma-node.tsx
@@ -45,6 +45,13 @@ export const FigmaNode: React.FC<NodeViewProps> = (props) => {
     if (!inputUrl.trim()) return
 
     const newEmbedUrl = getFigmaEmbedUrl(inputUrl)
+
+    // 유효하지 않은 URL인 경우 사용자에게 알림
+    if (!newEmbedUrl) {
+      alert("유효한 Figma URL을 입력해주세요.")
+      return
+    }
+
     setEmbedUrl(newEmbedUrl)
     setOriginalUrl(inputUrl)
     setIsEditing(false)

--- a/src/app/components/tiptap/tiptap-node/figma-node/figma-utils.ts
+++ b/src/app/components/tiptap/tiptap-node/figma-node/figma-utils.ts
@@ -3,15 +3,21 @@
  */
 
 const ALLOWED_FIGMA_HOSTS = ["figma.com", "www.figma.com", "embed.figma.com"]
+const ALLOWED_PROTOCOLS = ["https:"]
 
 /**
  * URL이 유효한 Figma URL인지 확인합니다.
+ * 프로토콜과 호스트 모두 검증하여 보안을 강화합니다.
  * @param url - 확인할 URL
  * @returns 유효한 Figma URL이면 true, 아니면 false
  */
 export function isValidFigmaUrl(url: string): boolean {
   try {
     const urlObj = new URL(url)
+    // 프로토콜 검증: javascript:, data: 등 위험한 프로토콜 차단
+    if (!ALLOWED_PROTOCOLS.includes(urlObj.protocol)) {
+      return false
+    }
     return ALLOWED_FIGMA_HOSTS.includes(urlObj.hostname)
   } catch {
     return false
@@ -64,9 +70,41 @@ export function getFigmaEmbedUrl(url: string): string {
 }
 
 /**
+ * URL이 iframe src에 사용하기 안전한 Figma 임베드 URL인지 확인합니다.
+ * XSS 공격을 방지하기 위해 프로토콜과 호스트를 엄격하게 검증합니다.
+ * @param url - 확인할 URL
+ * @returns 안전한 URL이면 해당 URL, 아니면 빈 문자열
+ */
+export function getSafeEmbedUrl(url: string): string {
+  if (!url || !url.trim()) {
+    return ""
+  }
+  
+  try {
+    const urlObj = new URL(url)
+    
+    // HTTPS 프로토콜만 허용
+    if (urlObj.protocol !== "https:") {
+      return ""
+    }
+    
+    // Figma 도메인만 허용
+    if (!ALLOWED_FIGMA_HOSTS.includes(urlObj.hostname)) {
+      return ""
+    }
+    
+    // 유효한 URL 반환
+    return urlObj.href
+  } catch {
+    return ""
+  }
+}
+
+/**
  * Figma 임베드 URL에서 원본 URL을 추출합니다.
+ * 추출된 URL도 유효성 검사를 수행하여 안전한 URL만 반환합니다.
  * @param embedUrl - 임베드 URL
- * @returns 원본 URL 또는 입력 URL 그대로
+ * @returns 유효한 원본 Figma URL 또는 빈 문자열
  */
 export function extractOriginalUrlFromEmbed(embedUrl: string): string {
   try {
@@ -75,7 +113,7 @@ export function extractOriginalUrlFromEmbed(embedUrl: string): string {
     // www.figma.com/embed?url=... 형식에서 원본 URL 추출
     if (urlObj.pathname.startsWith("/embed")) {
       const originalUrl = urlObj.searchParams.get("url")
-      if (originalUrl) {
+      if (originalUrl && isValidFigmaUrl(originalUrl)) {
         return originalUrl
       }
     }
@@ -86,13 +124,20 @@ export function extractOriginalUrlFromEmbed(embedUrl: string): string {
       const pathMatch = urlObj.pathname.match(/^\/([^/]+)\/([a-zA-Z0-9_-]+)/)
       if (pathMatch) {
         const [, type, fileKey] = pathMatch
-        return `https://www.figma.com/${type}/${fileKey}`
+        const reconstructedUrl = `https://www.figma.com/${type}/${fileKey}`
+        // 재구성된 URL도 유효성 검사 수행
+        if (isValidFigmaUrl(reconstructedUrl)) {
+          return reconstructedUrl
+        }
       }
     }
 
-    // 추출 실패 시 원본 반환
-    return embedUrl
+    // 입력이 유효한 Figma URL이면 그대로 반환, 아니면 빈 문자열 반환
+    if (isValidFigmaUrl(embedUrl)) {
+      return embedUrl
+    }
+    return ""
   } catch {
-    return embedUrl
+    return ""
   }
 }

--- a/src/app/components/tiptap/tiptap-node/figma-node/figma-utils.ts
+++ b/src/app/components/tiptap/tiptap-node/figma-node/figma-utils.ts
@@ -1,0 +1,98 @@
+/**
+ * Figma URL을 임베드 URL로 변환하는 유틸리티 함수
+ */
+
+const ALLOWED_FIGMA_HOSTS = ["figma.com", "www.figma.com", "embed.figma.com"]
+
+/**
+ * URL이 유효한 Figma URL인지 확인합니다.
+ * @param url - 확인할 URL
+ * @returns 유효한 Figma URL이면 true, 아니면 false
+ */
+export function isValidFigmaUrl(url: string): boolean {
+  try {
+    const urlObj = new URL(url)
+    return ALLOWED_FIGMA_HOSTS.includes(urlObj.hostname)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * URL이 이미 Figma 임베드 URL인지 확인합니다.
+ * @param url - 확인할 URL
+ * @returns 이미 임베드 형식이면 true, 아니면 false
+ */
+export function isAlreadyEmbedUrl(url: string): boolean {
+  try {
+    const urlObj = new URL(url)
+    return (
+      urlObj.hostname === "embed.figma.com" ||
+      urlObj.pathname.startsWith("/embed")
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Figma URL을 임베드 URL로 변환합니다.
+ * - 이미 임베드 URL인 경우 그대로 반환합니다.
+ * - 유효하지 않은 URL이면 빈 문자열을 반환합니다.
+ *
+ * @param url - 변환할 Figma URL
+ * @returns 임베드 URL 또는 빈 문자열
+ */
+export function getFigmaEmbedUrl(url: string): string {
+  // URL이 비어있으면 빈 문자열 반환
+  if (!url || !url.trim()) {
+    return ""
+  }
+
+  // URL 유효성 검사
+  if (!isValidFigmaUrl(url)) {
+    return ""
+  }
+
+  // 이미 임베드 URL이면 그대로 반환
+  if (isAlreadyEmbedUrl(url)) {
+    return url
+  }
+
+  // 표준 Figma 임베드 형식으로 변환
+  return `https://www.figma.com/embed?embed_host=share&url=${encodeURIComponent(url)}`
+}
+
+/**
+ * Figma 임베드 URL에서 원본 URL을 추출합니다.
+ * @param embedUrl - 임베드 URL
+ * @returns 원본 URL 또는 입력 URL 그대로
+ */
+export function extractOriginalUrlFromEmbed(embedUrl: string): string {
+  try {
+    const urlObj = new URL(embedUrl)
+
+    // www.figma.com/embed?url=... 형식에서 원본 URL 추출
+    if (urlObj.pathname.startsWith("/embed")) {
+      const originalUrl = urlObj.searchParams.get("url")
+      if (originalUrl) {
+        return originalUrl
+      }
+    }
+
+    // embed.figma.com 형식인 경우 원본 URL 추출 시도
+    if (urlObj.hostname === "embed.figma.com") {
+      // embed.figma.com/{type}/{fileKey} 형식에서 원본 URL 재구성
+      const pathMatch = urlObj.pathname.match(/^\/([^/]+)\/([a-zA-Z0-9]+)/)
+      if (pathMatch) {
+        const [, type, fileKey] = pathMatch
+        return `https://www.figma.com/${type}/${fileKey}`
+      }
+    }
+
+    // 추출 실패 시 원본 반환
+    return embedUrl
+  } catch {
+    return embedUrl
+  }
+}

--- a/src/app/components/tiptap/tiptap-node/figma-node/figma-utils.ts
+++ b/src/app/components/tiptap/tiptap-node/figma-node/figma-utils.ts
@@ -83,7 +83,7 @@ export function extractOriginalUrlFromEmbed(embedUrl: string): string {
     // embed.figma.com 형식인 경우 원본 URL 추출 시도
     if (urlObj.hostname === "embed.figma.com") {
       // embed.figma.com/{type}/{fileKey} 형식에서 원본 URL 재구성
-      const pathMatch = urlObj.pathname.match(/^\/([^/]+)\/([a-zA-Z0-9]+)/)
+      const pathMatch = urlObj.pathname.match(/^\/([^/]+)\/([a-zA-Z0-9_-]+)/)
       if (pathMatch) {
         const [, type, fileKey] = pathMatch
         return `https://www.figma.com/${type}/${fileKey}`

--- a/src/services/team/getTeamData.server.ts
+++ b/src/services/team/getTeamData.server.ts
@@ -86,6 +86,7 @@ export const getTeamData = async (
     description: teamProfile.description,
     created_at: teamProfile.created_at,
     owner: teamProfile.owner,
+    profile_html_description: teamProfile.profile_html_description,
     profile_link: (teamProfile.profile_link || []).map(
       (link: { link: string; alt: string | null }) => ({
         link: link.link,


### PR DESCRIPTION
## 💡 개요
Figma Deck 및 Slides 등 다양한 Figma URL 형식이 에디터에서 올바르게 임베드되지 않는 문제를 해결하고, 이미 임베드된 URL에 대한 중복 인코딩 방지 로직을 추가했습니다.
## 📃 작업내용
- **Figma Embed URL 변환 로직 개선**
  - 기존의 복잡한 파일 ID 추출 방식 대신, Figma의 표준 임베드 엔드포인트(`https://www.figma.com/embed?embed_host=share&url=...`)를 사용하도록 변경했습니다.
  - 이를 통해 Design, Proto 뿐만 아니라 Deck, Slides 등 모든 Figma 파일 형식을 지원합니다.
- **Direct Embed URL 지원**
  - `embed.figma.com` 도메인으로 시작하는 직접 임베드 URL을 그대로 허용하도록 수정했습니다.
- **중복 인코딩 방지**
  - 사용자가 이미 변환된 `www.figma.com/embed` 형식의 URL을 입력할 경우, 이를 감지하여 이중으로 인코딩되지 않도록 예외 처리를 추가했습니다.

## 🔀 변경사항
- `src/app/components/tiptap/tiptap-node/figma-node/figma-node.tsx`: getFigmaEmbedUrl  함수 로직 전면 수정
- `src/app/components/tiptap/tiptap-node/figma-node/figma-node-extension.ts` : 동일한 로직 적용 및 동기화

## 📸 스크린샷
