### PR TITLE
[I25-381] 1차 성능 개선

### DIFF
--- a/src/services/supabase/middleware.server.ts
+++ b/src/services/supabase/middleware.server.ts
@@ -8,7 +8,7 @@ export async function updateSession(request: NextRequest) {
 
   const supabase = await createClient();
 
-  // Do not run code between createServerClient and
+  // Do not run code between createClient and
   // supabase.auth.getUser(). A simple mistake could make it very hard to debug
   // issues with users being randomly logged out.
 

--- a/src/services/supabase/middleware.server.ts
+++ b/src/services/supabase/middleware.server.ts
@@ -1,14 +1,58 @@
+import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
-import { createClient } from './server';
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
   });
 
-  const supabase = await createClient();
+  // INTERNAL URL에서 사용할 호스트명의 프리픽스 추출
+  const publicHost = new URL(process.env.NEXT_PUBLIC_SUPABASE_URL!).host;
+  const internalHost = new URL(process.env.NEXT_PUBLIC_SUPABASE_INTERNAL_URL!)
+    .host;
+  const publicPrefix = `sb-${publicHost?.split('.')[0]}`;
+  const internalPrefix = `sb-${internalHost?.split('.')[0]}`;
 
-  // Do not run code between createClient and
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_INTERNAL_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          const cookies = request.cookies.getAll();
+          const result = [...cookies];
+          // sb-bsmhub-* 쿠키를 sb-10-* 형식으로 복사하여 INTERNAL URL에서 사용할 수 있도록 함
+          cookies.forEach((c) => {
+            if (c.name.startsWith(publicPrefix)) {
+              result.push({
+                name: c.name.replace(publicPrefix, internalPrefix),
+                value: c.value,
+              });
+            }
+          });
+          return result;
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          );
+          supabaseResponse = NextResponse.next({
+            request,
+          });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, {
+              ...options,
+              path: '/',
+              sameSite:
+                (options?.sameSite as 'lax' | 'strict' | 'none') || 'lax',
+            }),
+          );
+        },
+      },
+    },
+  );
+
+  // Do not run code between createServerClient and
   // supabase.auth.getUser(). A simple mistake could make it very hard to debug
   // issues with users being randomly logged out.
 

--- a/src/services/supabase/middleware.server.ts
+++ b/src/services/supabase/middleware.server.ts
@@ -1,37 +1,12 @@
-import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
+import { createClient } from './server';
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
   });
 
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll();
-        },
-        setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value }) =>
-            request.cookies.set(name, value),
-          );
-          supabaseResponse = NextResponse.next({
-            request,
-          });
-          cookiesToSet.forEach(({ name, value, options }) =>
-            supabaseResponse.cookies.set(name, value, {
-              ...options,
-              path: '/',
-              sameSite: (options?.sameSite as 'lax' | 'strict' | 'none') || 'lax',
-            }),
-          );
-        },
-      },
-    },
-  );
+  const supabase = await createClient();
 
   // Do not run code between createServerClient and
   // supabase.auth.getUser(). A simple mistake could make it very hard to debug
@@ -56,14 +31,14 @@ export async function updateSession(request: NextRequest) {
       const cookies = request.cookies.getAll();
       cookies.forEach(({ name }) => {
         if (name.startsWith('sb-')) {
-           supabaseResponse.cookies.set(name, '', { maxAge: 0 });
+          supabaseResponse.cookies.set(name, '', { maxAge: 0 });
         }
       });
       // Also clear the main response cookies just in case
       request.cookies.getAll().forEach(({ name }) => {
-         if (name.startsWith('sb-')) {
-            request.cookies.set(name, '');
-         }
+        if (name.startsWith('sb-')) {
+          request.cookies.set(name, '');
+        }
       });
     }
   }
@@ -96,4 +71,3 @@ export async function updateSession(request: NextRequest) {
 
   return supabaseResponse;
 }
-


### PR DESCRIPTION
## 💡 개요
최대 1분 가까이 소요되던 토큰 refresh api를 Supabase INTERNAL URL로 호출하도록 변경함. 
<img width="1433" height="1014" alt="image" src="https://github.com/user-attachments/assets/bd1c25e5-9c30-42a3-8090-0785b27f5224" />

### 추가 개선방향
- OAuth Code 교환 시 INTERNAL URL 사용하도록 변경
- 연쇄적 API 호출 구조 개선
  <img width="579" height="237" alt="image" src="https://github.com/user-attachments/assets/1c057a26-3a01-4847-81a6-c4fbcd28ff55" />

## 📃 작업내용

## 🔀 변경사항

## 📸 스크린샷
