### PR TITLE
[I25-395] [I25-394] feat: 프로필 구성에 이메일 필드 추가

### DIFF
--- a/src/services/config/profileConfig.ts
+++ b/src/services/config/profileConfig.ts
@@ -47,6 +47,7 @@ export const profileConfig: FormConfig = {
               profile_name
               profile_image
               description
+              email
               owner
               profile_linkCollection {
                 edges {
@@ -127,6 +128,7 @@ export const profileConfig: FormConfig = {
             profile_name
             profile_image
             description
+            email
             owner
             is_team
           }
@@ -215,6 +217,28 @@ export const profileConfig: FormConfig = {
             placeholder: '자기소개를 입력하세요',
             required: false,
             textarea: true,
+          },
+        ],
+      },
+    },
+    {
+      fieldName: 'profile_email',
+      label: '이메일',
+      type: 'inputList',
+      required: false,
+      columnInfo: { table: 'profile', column: 'email' },
+      inputConfig: {
+        onlyOne: true,
+        inputs: [
+          {
+            name: 'email',
+            type: 'text',
+            placeholder: '이메일을 입력하세요',
+            required: false,
+            zodSchema: z.union([
+              z.string().email('올바른 이메일 형식이 아닙니다.'),
+              z.literal(''),
+            ]),
           },
         ],
       },

--- a/src/services/config/teamProfileConfig.ts
+++ b/src/services/config/teamProfileConfig.ts
@@ -47,6 +47,7 @@ export const teamProfileConfig: FormConfig = {
               profile_name
               profile_image
               description
+              email
               owner
               profile_linkCollection {
                 edges {
@@ -87,6 +88,7 @@ export const teamProfileConfig: FormConfig = {
             profile_name
             profile_image
             description
+            email
             owner
             is_team
           }
@@ -147,6 +149,28 @@ export const teamProfileConfig: FormConfig = {
             type: 'text',
             placeholder: '자기소개를 입력하세요',
             required: false,
+          },
+        ],
+      },
+    },
+    {
+      fieldName: 'profile_email',
+      label: '이메일',
+      type: 'inputList',
+      required: false,
+      columnInfo: { table: 'profile', column: 'email' },
+      inputConfig: {
+        onlyOne: true,
+        inputs: [
+          {
+            name: 'email',
+            type: 'text',
+            placeholder: '이메일을 입력하세요',
+            required: false,
+            zodSchema: z.union([
+              z.string().email('올바른 이메일 형식이 아닙니다.'),
+              z.literal(''),
+            ]),
           },
         ],
       },


### PR DESCRIPTION
## 💡 개요
팀이나 학생의 모달에 이메일을 입력 가능하도록 만듬.

## 📃 작업내용

## 🔀 변경사항

## 📸 스크린샷
<img width="1216" height="1170" alt="image" src="https://github.com/user-attachments/assets/a87c1cf0-5cde-4876-b969-b19134308c54" />
<img width="1225" height="1763" alt="image" src="https://github.com/user-attachments/assets/cc74b065-f304-46fe-8e2e-59a3ecb9461e" />
