### PR TITLE
I25 394 viewer 필터 만들기

### DIFF
--- a/src/app/(box-layout)/viewer/ViewerContent.tsx
+++ b/src/app/(box-layout)/viewer/ViewerContent.tsx
@@ -7,8 +7,7 @@ import FilterSidebar, { FilterState } from '@/app/components/portfolio/FilterSid
 import { ViewerPortfolioData } from '@/services/portfolio/getAllViewerPortfolioData.server';
 import { Tables } from '@/services/supabase/database.types';
 
-const JOB_SEEKING_STATUS = ['구직 중', 'jobseeking'];
-const EMPLOYED_STATUS = ['취직 중', 'employed'];
+import { JOB_SEEKING_STATUS, EMPLOYED_STATUS } from '@/app/components/portfolio/constants';
 
 interface ViewerContentProps {
   portfolioData: ViewerPortfolioData[];

--- a/src/app/(box-layout)/viewer/ViewerContent.tsx
+++ b/src/app/(box-layout)/viewer/ViewerContent.tsx
@@ -3,12 +3,15 @@
 import { useState, useMemo } from 'react';
 import Image from 'next/image';
 import PortfolioSheet from '@/app/components/viewer/PortfolioSheet';
-import FilterSidebar, { FilterState } from '@/app/components/portfolio/FilterSidebar';
+import FilterSidebar from '@/app/components/portfolio/FilterSidebar';
 import { ViewerPortfolioData } from '@/services/portfolio/getAllViewerPortfolioData.server';
 import { Tables } from '@/services/supabase/database.types';
-import { extractUniqueDepartments } from '@/utils/portfolioUtils';
-
-import { JOB_SEEKING_STATUS, EMPLOYED_STATUS } from '@/app/components/portfolio/constants';
+import {
+  extractUniqueDepartments,
+  filterPortfolioData,
+  FilterState,
+  PortfolioFilterAccessors,
+} from '@/utils/portfolioUtils';
 
 interface ViewerContentProps {
   portfolioData: ViewerPortfolioData[];
@@ -23,8 +26,21 @@ const getBanner = (dept: string | null): string | null => {
   return null;
 };
 
-export default function ViewerContent({ portfolioData, jobs, showFilter }: ViewerContentProps) {
+// ViewerPortfolioData용 필터 접근자
+const viewerAccessors: PortfolioFilterAccessors<ViewerPortfolioData> = {
+  getProfileName: (data) => data.profile.profile_name,
+  getStudentName: (data) => data.student?.name,
+  getProjects: (data) =>
+    data.projects.map((p) => ({
+      name: p.project_name,
+      description: p.description,
+    })),
+  getDepartmentName: (data) => data.department?.department_name,
+  getRoles: (data) => data.profile.role,
+  getStatus: (data) => data.profile.status,
+};
 
+export default function ViewerContent({ portfolioData, jobs, showFilter }: ViewerContentProps) {
   const [searchTerm, setSearchTerm] = useState('');
   const [filter, setFilter] = useState<FilterState>({
     jobs: [],
@@ -39,58 +55,10 @@ export default function ViewerContent({ portfolioData, jobs, showFilter }: Viewe
     [portfolioData],
   );
 
-  // 필터링 함수들
-  const filterBySearchTerm = (data: ViewerPortfolioData) => {
-    if (!searchTerm) return true;
-    const searchLower = searchTerm.toLowerCase();
-    return (
-      data.profile.profile_name?.toLowerCase().includes(searchLower) ||
-      data.student?.name?.toLowerCase().includes(searchLower) ||
-      data.projects.some(
-        (project) =>
-          project.project_name?.toLowerCase().includes(searchLower) ||
-          project.description?.toLowerCase().includes(searchLower),
-      )
-    );
-  };
-
-  const filterByDepartments = (data: ViewerPortfolioData) => {
-    if (filter.departments.length === 0) return true;
-    const deptName = data.department?.department_name;
-    return deptName ? filter.departments.includes(deptName) : false;
-  };
-
-  const filterByJobs = (data: ViewerPortfolioData) => {
-    if (filter.jobs.length === 0) return true;
-    return data.profile.role.some((role) => filter.jobs.includes(role));
-  };
-
-  const filterByEmploymentStatus = (data: ViewerPortfolioData) => {
-    const { showOnlyJobSeeking, showOnlyEmployed } = filter;
-    // 둘 다 선택되거나 둘 다 선택되지 않은 경우
-    if (showOnlyJobSeeking === showOnlyEmployed) return true;
-
-    const status = data.profile.status;
-
-    if (showOnlyJobSeeking) {
-      return JOB_SEEKING_STATUS.includes(status);
-    }
-
-    if (showOnlyEmployed) {
-      return EMPLOYED_STATUS.includes(status);
-    }
-
-    return true;
-  };
-
-  // 필터링된 데이터
+  // 필터링된 데이터 (공통 유틸리티 함수 사용)
   const filteredData = useMemo(() => {
     if (!showFilter) return portfolioData;
-    return portfolioData
-      .filter(filterBySearchTerm)
-      .filter(filterByDepartments)
-      .filter(filterByJobs)
-      .filter(filterByEmploymentStatus);
+    return filterPortfolioData(portfolioData, searchTerm, filter, viewerAccessors);
   }, [portfolioData, showFilter, searchTerm, filter]);
 
   // 배너와 포트폴리오 아이템 생성

--- a/src/app/(box-layout)/viewer/ViewerContent.tsx
+++ b/src/app/(box-layout)/viewer/ViewerContent.tsx
@@ -6,6 +6,7 @@ import PortfolioSheet from '@/app/components/viewer/PortfolioSheet';
 import FilterSidebar, { FilterState } from '@/app/components/portfolio/FilterSidebar';
 import { ViewerPortfolioData } from '@/services/portfolio/getAllViewerPortfolioData.server';
 import { Tables } from '@/services/supabase/database.types';
+import { extractUniqueDepartments } from '@/utils/portfolioUtils';
 
 const JOB_SEEKING_STATUS = ['구직 중', 'jobseeking'];
 const EMPLOYED_STATUS = ['취직 중', 'employed'];
@@ -33,17 +34,11 @@ export default function ViewerContent({ portfolioData, jobs, showFilter }: Viewe
     showOnlyEmployed: false,
   });
 
-  // 고유한 학과 목록 추출
-  const departments = useMemo(() => {
-    const deptSet = new Set<string>();
-    portfolioData.forEach((data) => {
-      const deptName = data.department?.department_name;
-      if (deptName) {
-        deptSet.add(deptName);
-      }
-    });
-    return Array.from(deptSet).sort((a, b) => a.localeCompare(b, 'ko'));
-  }, [portfolioData]);
+  // 고유한 학과 목록 추출 (공통 유틸리티 함수 사용)
+  const departments = useMemo(
+    () => extractUniqueDepartments(portfolioData, (data) => data.department?.department_name),
+    [portfolioData],
+  );
 
   // 필터링 함수들
   const filterBySearchTerm = (data: ViewerPortfolioData) => {

--- a/src/app/(box-layout)/viewer/ViewerContent.tsx
+++ b/src/app/(box-layout)/viewer/ViewerContent.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import Image from 'next/image';
+import PortfolioSheet from '@/app/components/viewer/PortfolioSheet';
+import FilterSidebar, { FilterState } from '@/app/components/portfolio/FilterSidebar';
+import { ViewerPortfolioData } from '@/services/portfolio/getAllViewerPortfolioData.server';
+import { Tables } from '@/services/supabase/database.types';
+
+const JOB_SEEKING_STATUS = ['구직 중', 'jobseeking'];
+const EMPLOYED_STATUS = ['취직 중', 'employed'];
+
+interface ViewerContentProps {
+  portfolioData: ViewerPortfolioData[];
+  jobs: Tables<'jobs'>[];
+  showFilter: boolean;
+}
+
+const getBanner = (dept: string | null): string | null => {
+  if (!dept) return null;
+  if (dept.includes('소프트웨어개발과') || dept.includes('소프트웨어 개발과')) return '/banner/s.png';
+  if (dept.includes('임베디드소프트웨어과') || dept.includes('임베디드 소프트웨어과')) return '/banner/es.png';
+  return null;
+};
+
+export default function ViewerContent({ portfolioData, jobs, showFilter }: ViewerContentProps) {
+
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filter, setFilter] = useState<FilterState>({
+    jobs: [],
+    departments: [],
+    showOnlyJobSeeking: false,
+    showOnlyEmployed: false,
+  });
+
+  // 고유한 학과 목록 추출
+  const departments = useMemo(() => {
+    const deptSet = new Set<string>();
+    portfolioData.forEach((data) => {
+      const deptName = data.department?.department_name;
+      if (deptName) {
+        deptSet.add(deptName);
+      }
+    });
+    return Array.from(deptSet).sort((a, b) => a.localeCompare(b, 'ko'));
+  }, [portfolioData]);
+
+  // 필터링 함수들
+  const filterBySearchTerm = (data: ViewerPortfolioData) => {
+    if (!searchTerm) return true;
+    const searchLower = searchTerm.toLowerCase();
+    return (
+      data.profile.profile_name?.toLowerCase().includes(searchLower) ||
+      data.student?.name?.toLowerCase().includes(searchLower) ||
+      data.projects.some(
+        (project) =>
+          project.project_name?.toLowerCase().includes(searchLower) ||
+          project.description?.toLowerCase().includes(searchLower),
+      )
+    );
+  };
+
+  const filterByDepartments = (data: ViewerPortfolioData) => {
+    if (filter.departments.length === 0) return true;
+    const deptName = data.department?.department_name;
+    return deptName ? filter.departments.includes(deptName) : false;
+  };
+
+  const filterByJobs = (data: ViewerPortfolioData) => {
+    if (filter.jobs.length === 0) return true;
+    return data.profile.role.some((role) => filter.jobs.includes(role));
+  };
+
+  const filterByEmploymentStatus = (data: ViewerPortfolioData) => {
+    const { showOnlyJobSeeking, showOnlyEmployed } = filter;
+    // 둘 다 선택되거나 둘 다 선택되지 않은 경우
+    if (showOnlyJobSeeking === showOnlyEmployed) return true;
+
+    const status = data.profile.status;
+
+    if (showOnlyJobSeeking) {
+      return JOB_SEEKING_STATUS.includes(status);
+    }
+
+    if (showOnlyEmployed) {
+      return EMPLOYED_STATUS.includes(status);
+    }
+
+    return true;
+  };
+
+  // 필터링된 데이터
+  const filteredData = useMemo(() => {
+    if (!showFilter) return portfolioData;
+    return portfolioData
+      .filter(filterBySearchTerm)
+      .filter(filterByDepartments)
+      .filter(filterByJobs)
+      .filter(filterByEmploymentStatus);
+  }, [portfolioData, showFilter, searchTerm, filter]);
+
+  // 배너와 포트폴리오 아이템 생성
+  const items = useMemo(() => {
+    const result: Array<{ type: 'banner'; src: string } | { type: 'portfolio'; data: ViewerPortfolioData }> = [];
+    let lastDept: string | null = null;
+
+    filteredData.forEach((data) => {
+      const dept = data.department?.department_name || null;
+      if (dept !== lastDept) {
+        const banner = getBanner(dept);
+        if (banner) result.push({ type: 'banner', src: banner });
+        lastDept = dept;
+      }
+      result.push({ type: 'portfolio', data });
+    });
+
+    return result;
+  }, [filteredData]);
+
+  if (!portfolioData?.length) {
+    return (
+      <div className="flex-center w-full py-8">
+        <p className="text-gray-500">표시할 포트폴리오가 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pt-12 flex mobile:flex-col flex-row gap-4 min-h-dvh w-full">
+      {/* 필터 사이드바 */}
+      {showFilter && (
+        <FilterSidebar
+          searchTerm={searchTerm}
+          onSearchChange={setSearchTerm}
+          filter={filter}
+          onFilterChange={setFilter}
+          jobs={jobs}
+          departments={departments}
+        />
+      )}
+
+      {/* 메인 콘텐츠 */}
+      <div className="flex-col gap-40 w-full">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 mobile:gap-20 w-full">
+          {items.map((item, i) =>
+            item.type === 'banner' ? (
+              <div key={`banner-${i}`} className="col-span-full relative w-full h-auto">
+                <Image
+                  src={item.src}
+                  alt="과 배너"
+                  width={1200}
+                  height={300}
+                  className="w-full h-auto object-contain"
+                  {...(items.findIndex((it) => it.type === 'banner') === i ? { priority: true } : {})}
+                />
+              </div>
+            ) : (
+              <PortfolioSheet key={item.data.profile.profile_name || i} data={item.data} />
+            ),
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/(box-layout)/viewer/ViewerStatic.tsx
+++ b/src/app/(box-layout)/viewer/ViewerStatic.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
 import PortfolioSheet from '@/app/components/viewer/PortfolioSheet';
-import { getAllViewerPortfolioData, ViewerPortfolioData } from '@/services/portfolio/getAllViewerPortfolioData.server';
-
-// Full Route Cache 설정 (1시간마다 재검증)
-export const revalidate = 3600;
+import { ViewerPortfolioData } from '@/services/portfolio/getAllViewerPortfolioData.server';
 
 const getBanner = (dept: string | null): string | null => {
   if (!dept) return null;
@@ -13,17 +10,12 @@ const getBanner = (dept: string | null): string | null => {
   return null;
 };
 
-const ViewerPage = async () => {
-  const portfolioData = await getAllViewerPortfolioData();
+interface ViewerStaticProps {
+  portfolioData: ViewerPortfolioData[];
+}
 
-  if (!portfolioData?.length) {
-    return (
-      <div className="flex-center w-full py-8">
-        <p className="text-gray-500">표시할 포트폴리오가 없습니다.</p>
-      </div>
-    );
-  }
-
+export default function ViewerStatic({ portfolioData }: ViewerStaticProps) {
+  // 배너와 포트폴리오 아이템 생성
   const items: Array<{ type: 'banner'; src: string } | { type: 'portfolio'; data: ViewerPortfolioData }> = [];
   let lastDept: string | null = null;
 
@@ -37,9 +29,17 @@ const ViewerPage = async () => {
     items.push({ type: 'portfolio', data });
   });
 
+  if (!portfolioData?.length) {
+    return (
+      <div className="flex-center w-full py-8">
+        <p className="text-gray-500">표시할 포트폴리오가 없습니다.</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex-col gap-40 w-full">
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-20 w-full">
+    <div className="pt-12 flex-col gap-40 w-full">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 mobile:gap-20 w-full">
         {items.map((item, i) =>
           item.type === 'banner' ? (
             <div key={`banner-${i}`} className="col-span-full relative w-full h-auto">
@@ -49,7 +49,7 @@ const ViewerPage = async () => {
                 width={1200}
                 height={300}
                 className="w-full h-auto object-contain"
-                {...(items.findIndex(it => it.type === 'banner') === i ? { priority: true } : {})}
+                {...(items.findIndex((it) => it.type === 'banner') === i ? { priority: true } : {})}
               />
             </div>
           ) : (
@@ -59,6 +59,5 @@ const ViewerPage = async () => {
       </div>
     </div>
   );
-};
+}
 
-export default ViewerPage;

--- a/src/app/(box-layout)/viewer/page.tsx
+++ b/src/app/(box-layout)/viewer/page.tsx
@@ -1,0 +1,37 @@
+import React, { Suspense } from 'react';
+import { getAllViewerPortfolioData } from '@/services/portfolio/getAllViewerPortfolioData.server';
+import getJobs from '@/services/portfolio/getJobs.server';
+import ViewerContent from './ViewerContent';
+import ViewerStatic from './ViewerStatic';
+import ViewerSkeleton from '@/app/components/viewer/ViewerSkeleton';
+
+// Full Route Cache 설정 (1시간마다 재검증)
+// filter 파라미터가 없을 때만 정적 렌더링
+export const revalidate = 3600;
+
+interface ViewerPageProps {
+  searchParams: Promise<{ filter?: string }>;
+}
+
+const ViewerPage = async ({ searchParams }: ViewerPageProps) => {
+  const params = await searchParams;
+  const showFilter = params.filter === 'true';
+
+  const portfolioData = await getAllViewerPortfolioData();
+  const jobs = await getJobs();
+
+  // filter 파라미터가 있으면 동적 렌더링 (클라이언트 컴포넌트), 없으면 정적 렌더링 (서버 컴포넌트)
+  if (showFilter) {
+    return (
+      <Suspense fallback={<ViewerSkeleton />}>
+        <ViewerContent portfolioData={portfolioData} jobs={jobs} showFilter={showFilter} />
+      </Suspense>
+    );
+  }
+
+  // 필터가 없을 때는 서버 컴포넌트로 정적 렌더링
+  return <ViewerStatic portfolioData={portfolioData} />;
+};
+
+export default ViewerPage;
+

--- a/src/app/(box-layout)/viewer/page.tsx
+++ b/src/app/(box-layout)/viewer/page.tsx
@@ -23,9 +23,7 @@ const ViewerPage = async ({ searchParams }: ViewerPageProps) => {
   // filter 파라미터가 있으면 동적 렌더링 (클라이언트 컴포넌트), 없으면 정적 렌더링 (서버 컴포넌트)
   if (showFilter) {
     return (
-      <Suspense fallback={<ViewerSkeleton />}>
-        <ViewerContent portfolioData={portfolioData} jobs={jobs} showFilter={showFilter} />
-      </Suspense>
+      <ViewerContent portfolioData={portfolioData} jobs={jobs} showFilter={showFilter} />
     );
   }
 

--- a/src/app/components/portfolio/FilterSidebar.tsx
+++ b/src/app/components/portfolio/FilterSidebar.tsx
@@ -4,13 +4,10 @@ import Inputs from '@/app/components/ui/input/SingleInput';
 import Checkbox from '@/app/components/ui/input/Checkbox';
 import { Body } from '@/app/components/ui/text/text';
 import { Tables } from '@/services/supabase/database.types';
+import { FilterState } from '@/utils/portfolioUtils';
 
-export interface FilterState {
-  jobs: string[];
-  departments: string[];
-  showOnlyJobSeeking: boolean;
-  showOnlyEmployed: boolean;
-}
+// 하위 호환성을 위해 FilterState를 re-export
+export type { FilterState };
 
 interface FilterSidebarProps {
   searchTerm: string;

--- a/src/app/components/portfolio/FilterSidebar.tsx
+++ b/src/app/components/portfolio/FilterSidebar.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import Inputs from '@/app/components/ui/input/SingleInput';
+import Checkbox from '@/app/components/ui/input/Checkbox';
+import { Body } from '@/app/components/ui/text/text';
+import { Tables } from '@/services/supabase/database.types';
+
+export interface FilterState {
+  jobs: string[];
+  departments: string[];
+  showOnlyJobSeeking: boolean;
+  showOnlyEmployed: boolean;
+}
+
+interface FilterSidebarProps {
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+  filter: FilterState;
+  onFilterChange: (filter: FilterState) => void;
+  jobs: Tables<'jobs'>[];
+  departments: string[];
+}
+
+export default function FilterSidebar({
+  searchTerm,
+  onSearchChange,
+  filter,
+  onFilterChange,
+  jobs,
+  departments,
+}: FilterSidebarProps) {
+  const handleJobFilter = (jobName: string, checked: boolean) => {
+    onFilterChange({
+      ...filter,
+      jobs: checked
+        ? [...filter.jobs, jobName]
+        : filter.jobs.filter((name) => name !== jobName),
+    });
+  };
+
+  const handleDepartmentFilter = (departmentName: string, checked: boolean) => {
+    onFilterChange({
+      ...filter,
+      departments: checked
+        ? [...filter.departments, departmentName]
+        : filter.departments.filter((name) => name !== departmentName),
+    });
+  };
+
+  const handleEmploymentFilter = (
+    filterType: 'jobSeeking' | 'employed',
+    checked: boolean,
+  ) => {
+    onFilterChange({
+      ...filter,
+      [filterType === 'jobSeeking' ? 'showOnlyJobSeeking' : 'showOnlyEmployed']:
+        checked,
+    });
+  };
+
+  return (
+    <aside className="flex-col gap-3 min-w-[25rem]">
+      <Inputs
+        icon="search"
+        onChange={(e) => onSearchChange(e.target.value)}
+        placeholder="Search"
+        value={searchTerm}
+      />
+
+      <div className="flex-col gap-3 p-2">
+        {/* 학과 필터 */}
+        <Body>학과</Body>
+        <div className="flex-col gap-1">
+          {departments.map((dept) => (
+            <Checkbox
+              label={dept}
+              key={dept}
+              checked={filter.departments.includes(dept)}
+              onChange={(checked) => handleDepartmentFilter(dept, checked)}
+            />
+          ))}
+        </div>
+
+        {/* 직무분야 필터 */}
+        <Body>직무분야</Body>
+        <div className="flex-col gap-1">
+          {jobs.map((job) => (
+            <Checkbox
+              label={job.job_name}
+              key={job.job_id}
+              checked={filter.jobs.includes(job.job_name)}
+              onChange={(checked) => handleJobFilter(job.job_name, checked)}
+            />
+          ))}
+        </div>
+
+        {/* 옵션 필터 */}
+        <Body>옵션</Body>
+        <div className="flex-col gap-1">
+          <Checkbox
+            label="구직 중만 표시"
+            checked={filter.showOnlyJobSeeking}
+            onChange={(checked) =>
+              handleEmploymentFilter('jobSeeking', checked)
+            }
+          />
+          <Checkbox
+            label="취직 중만 표시"
+            checked={filter.showOnlyEmployed}
+            onChange={(checked) =>
+              handleEmploymentFilter('employed', checked)
+            }
+          />
+        </div>
+      </div>
+    </aside>
+  );
+}
+

--- a/src/app/components/portfolio/SearchTab.tsx
+++ b/src/app/components/portfolio/SearchTab.tsx
@@ -48,7 +48,10 @@ export default function SearchTab({
   );
 
   // 필터링된 데이터 (공통 유틸리티 함수 사용)
-  const filteredData = filterPortfolioData(portfolioData, searchTerm, filter, searchTabAccessors);
+  const filteredData = useMemo(
+    () => filterPortfolioData(portfolioData, searchTerm, filter, searchTabAccessors),
+    [portfolioData, searchTerm, filter],
+  );
 
   return (
     <div className="pt-8 flex mobile:flex-col flex-row gap-4 min-h-dvh w-full">

--- a/src/app/components/portfolio/SearchTab.tsx
+++ b/src/app/components/portfolio/SearchTab.tsx
@@ -5,6 +5,7 @@ import PortfolioCard from '@/app/components/card/portfolio/PortfolioCard';
 import { PortfolioData } from './types';
 import FilterSidebar, { FilterState } from './FilterSidebar';
 import { Tables } from '@/services/supabase/database.types';
+import { extractUniqueDepartments } from '@/utils/portfolioUtils';
 
 const JOB_SEEKING_STATUS = ['구직 중', 'jobseeking'];
 const EMPLOYED_STATUS = ['취직 중', 'employed'];
@@ -24,17 +25,11 @@ export default function SearchTab({
     showOnlyEmployed: false,
   });
 
-  // 고유한 학과 목록 추출
-  const departments = useMemo(() => {
-    const deptSet = new Set<string>();
-    portfolioData.forEach((data) => {
-      const deptName = data.student?.department?.department_name;
-      if (deptName) {
-        deptSet.add(deptName);
-      }
-    });
-    return Array.from(deptSet).sort((a, b) => a.localeCompare(b, 'ko'));
-  }, [portfolioData]);
+  // 고유한 학과 목록 추출 (공통 유틸리티 함수 사용)
+  const departments = useMemo(
+    () => extractUniqueDepartments(portfolioData, (data) => data.student?.department?.department_name),
+    [portfolioData],
+  );
 
   // 필터링 함수들
   const filterBySearchTerm = (data: PortfolioData) => {

--- a/src/app/components/portfolio/SearchTab.tsx
+++ b/src/app/components/portfolio/SearchTab.tsx
@@ -6,8 +6,7 @@ import { PortfolioData } from './types';
 import FilterSidebar, { FilterState } from './FilterSidebar';
 import { Tables } from '@/services/supabase/database.types';
 
-const JOB_SEEKING_STATUS = ['구직 중', 'jobseeking'];
-const EMPLOYED_STATUS = ['취직 중', 'employed'];
+import { JOB_SEEKING_STATUS, EMPLOYED_STATUS } from './constants';
 
 export default function SearchTab({
   portfolioData,

--- a/src/app/components/portfolio/SearchTab.tsx
+++ b/src/app/components/portfolio/SearchTab.tsx
@@ -1,21 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import PortfolioCard from '@/app/components/card/portfolio/PortfolioCard';
 import { PortfolioData } from './types';
-import Inputs from '@/app/components/ui/input/SingleInput';
-import Checkbox from '@/app/components/ui/input/Checkbox';
-import { Body } from '@/app/components/ui/text/text';
+import FilterSidebar, { FilterState } from './FilterSidebar';
 import { Tables } from '@/services/supabase/database.types';
 
 const JOB_SEEKING_STATUS = ['구직 중', 'jobseeking'];
 const EMPLOYED_STATUS = ['취직 중', 'employed'];
-
-interface FilterState {
-  jobs: string[];
-  showOnlyJobSeeking: boolean;
-  showOnlyEmployed: boolean;
-}
 
 export default function SearchTab({
   portfolioData,
@@ -27,9 +19,22 @@ export default function SearchTab({
   const [searchTerm, setSearchTerm] = useState('');
   const [filter, setFilter] = useState<FilterState>({
     jobs: [],
+    departments: [],
     showOnlyJobSeeking: false,
     showOnlyEmployed: false,
   });
+
+  // 고유한 학과 목록 추출
+  const departments = useMemo(() => {
+    const deptSet = new Set<string>();
+    portfolioData.forEach((data) => {
+      const deptName = data.student?.department?.department_name;
+      if (deptName) {
+        deptSet.add(deptName);
+      }
+    });
+    return Array.from(deptSet).sort((a, b) => a.localeCompare(b, 'ko'));
+  }, [portfolioData]);
 
   // 필터링 함수들
   const filterBySearchTerm = (data: PortfolioData) => {
@@ -43,6 +48,12 @@ export default function SearchTab({
           project.description.toLowerCase().includes(searchTerm.toLowerCase()),
       )
     );
+  };
+
+  const filterByDepartments = (data: PortfolioData) => {
+    if (filter.departments.length === 0) return true;
+    const deptName = data.student?.department?.department_name;
+    return deptName ? filter.departments.includes(deptName) : false;
   };
 
   const filterByJobs = (data: PortfolioData) => {
@@ -68,73 +79,24 @@ export default function SearchTab({
     return true;
   };
 
-  // 핸들러 함수들
-  const handleJobFilter = (jobName: string, checked: boolean) => {
-    setFilter((prev) => ({
-      ...prev,
-      jobs: checked
-        ? [...prev.jobs, jobName]
-        : prev.jobs.filter((name) => name !== jobName),
-    }));
-  };
-
-  const handleEmploymentFilter = (
-    filterType: 'jobSeeking' | 'employed',
-    checked: boolean,
-  ) => {
-    setFilter((prev) => ({
-      ...prev,
-      [filterType === 'jobSeeking' ? 'showOnlyJobSeeking' : 'showOnlyEmployed']:
-        checked,
-    }));
-  };
-
   // 필터링된 데이터
   const filteredData = portfolioData
     .filter(filterBySearchTerm)
+    .filter(filterByDepartments)
     .filter(filterByJobs)
     .filter(filterByEmploymentStatus);
+
   return (
     <div className="pt-8 flex mobile:flex-col flex-row gap-4 min-h-dvh w-full">
       {/* 검색 및 필터 사이드바 */}
-      <aside className="flex-col gap-3 min-w-[25rem]">
-        <Inputs
-          icon="search"
-          onChange={(e) => setSearchTerm(e.target.value)}
-          placeholder="Search"
-        />
-
-        <div className="flex-col gap-3 p-2">
-          {/* 직무분야 필터 */}
-          <Body>직무분야</Body>
-          <div className="flex-col gap-1">
-            {jobs.map((job) => (
-              <Checkbox
-                label={job.job_name}
-                key={job.job_id}
-                onChange={(checked) => handleJobFilter(job.job_name, checked)}
-              />
-            ))}
-          </div>
-
-          {/* 옵션 필터 */}
-          <Body>옵션</Body>
-          <div className="flex-col gap-1">
-            <Checkbox
-              label="구직 중만 표시"
-              onChange={(checked) =>
-                handleEmploymentFilter('jobSeeking', checked)
-              }
-            />
-            <Checkbox
-              label="취직 중만 표시"
-              onChange={(checked) =>
-                handleEmploymentFilter('employed', checked)
-              }
-            />
-          </div>
-        </div>
-      </aside>
+      <FilterSidebar
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
+        filter={filter}
+        onFilterChange={setFilter}
+        jobs={jobs}
+        departments={departments}
+      />
 
       {/* 포트폴리오 목록 */}
       <section className="flex-col gap-3 p-4 w-full bg-[#FAFAFA] rounded-lg">

--- a/src/app/components/portfolio/SearchTab.tsx
+++ b/src/app/components/portfolio/SearchTab.tsx
@@ -3,11 +3,28 @@
 import { useState, useMemo } from 'react';
 import PortfolioCard from '@/app/components/card/portfolio/PortfolioCard';
 import { PortfolioData } from './types';
-import FilterSidebar, { FilterState } from './FilterSidebar';
+import FilterSidebar from './FilterSidebar';
 import { Tables } from '@/services/supabase/database.types';
-import { extractUniqueDepartments } from '@/utils/portfolioUtils';
+import {
+  extractUniqueDepartments,
+  filterPortfolioData,
+  FilterState,
+  PortfolioFilterAccessors,
+} from '@/utils/portfolioUtils';
 
-import { JOB_SEEKING_STATUS, EMPLOYED_STATUS } from './constants';
+// PortfolioData용 필터 접근자
+const searchTabAccessors: PortfolioFilterAccessors<PortfolioData> = {
+  getProfileName: (data) => data.profile.name,
+  getStudentName: (data) => data.student?.name,
+  getProjects: (data) =>
+    data.projects.map((p) => ({
+      name: p.title,
+      description: p.description,
+    })),
+  getDepartmentName: (data) => data.student?.department?.department_name,
+  getRoles: (data) => data.profile.role,
+  getStatus: (data) => data.profile.status,
+};
 
 export default function SearchTab({
   portfolioData,
@@ -30,55 +47,8 @@ export default function SearchTab({
     [portfolioData],
   );
 
-  // 필터링 함수들
-  const filterBySearchTerm = (data: PortfolioData) => {
-    if (!searchTerm) return true;
-    return (
-      data.profile.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      data.student?.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      data.projects.some(
-        (project) =>
-          project.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          project.description.toLowerCase().includes(searchTerm.toLowerCase()),
-      )
-    );
-  };
-
-  const filterByDepartments = (data: PortfolioData) => {
-    if (filter.departments.length === 0) return true;
-    const deptName = data.student?.department?.department_name;
-    return deptName ? filter.departments.includes(deptName) : false;
-  };
-
-  const filterByJobs = (data: PortfolioData) => {
-    if (filter.jobs.length === 0) return true;
-    return data.profile.role.some((role) => filter.jobs.includes(role));
-  };
-
-  const filterByEmploymentStatus = (data: PortfolioData) => {
-    const { showOnlyJobSeeking, showOnlyEmployed } = filter;
-    // 둘 다 선택되거나 둘 다 선택되지 않은 경우
-    if (showOnlyJobSeeking === showOnlyEmployed) return true;
-
-    const status = data.profile.status;
-
-    if (showOnlyJobSeeking) {
-      return JOB_SEEKING_STATUS.includes(status);
-    }
-
-    if (showOnlyEmployed) {
-      return EMPLOYED_STATUS.includes(status);
-    }
-
-    return true;
-  };
-
-  // 필터링된 데이터
-  const filteredData = portfolioData
-    .filter(filterBySearchTerm)
-    .filter(filterByDepartments)
-    .filter(filterByJobs)
-    .filter(filterByEmploymentStatus);
+  // 필터링된 데이터 (공통 유틸리티 함수 사용)
+  const filteredData = filterPortfolioData(portfolioData, searchTerm, filter, searchTabAccessors);
 
   return (
     <div className="pt-8 flex mobile:flex-col flex-row gap-4 min-h-dvh w-full">

--- a/src/app/components/viewer/ViewerSkeleton.tsx
+++ b/src/app/components/viewer/ViewerSkeleton.tsx
@@ -1,0 +1,66 @@
+export default function ViewerSkeleton() {
+  return (
+    <div className="pt-12 flex mobile:flex-col flex-row gap-4 min-h-dvh w-full">
+      {/* 필터 사이드바 스켈레톤 */}
+      <aside className="flex-col gap-3 min-w-[25rem]">
+        <div className="h-10 bg-gray-200 rounded animate-pulse" />
+        <div className="flex-col gap-3 p-2">
+          <div className="h-5 bg-gray-200 rounded w-20 animate-pulse" />
+          <div className="flex-col gap-1">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-6 bg-gray-200 rounded animate-pulse" />
+            ))}
+          </div>
+          <div className="h-5 bg-gray-200 rounded w-16 mt-4 animate-pulse" />
+          <div className="flex-col gap-1">
+            {[1, 2].map((i) => (
+              <div key={i} className="h-6 bg-gray-200 rounded animate-pulse" />
+            ))}
+          </div>
+        </div>
+      </aside>
+
+      {/* 메인 콘텐츠 스켈레톤 */}
+      <div className="flex-col gap-40 w-full">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 mobile:gap-20 w-full">
+          {[1, 2, 3, 4].map((i) => (
+            <div
+              key={i}
+              className="flex-col gap-[24px] w-full border border-[#F3F3F3] rounded p-8 bg-white"
+            >
+              {/* 프로필 이미지 및 정보 스켈레톤 */}
+              <div className="flex-center gap-[20px] w-full">
+                <div className="h-[213px] w-[166px] bg-gray-200 rounded animate-pulse shrink-0" />
+                <div className="flex-col h-[213px] justify-between shrink-0 flex-1">
+                  <div className="flex-col gap-[7px] w-full">
+                    <div className="h-8 bg-gray-200 rounded w-32 animate-pulse" />
+                    <div className="h-5 bg-gray-200 rounded w-48 animate-pulse" />
+                    <div className="h-16 bg-gray-200 rounded w-full animate-pulse" />
+                  </div>
+                  <div className="flex-col gap-[3px]">
+                    <div className="h-4 bg-gray-200 rounded w-24 animate-pulse" />
+                    <div className="h-5 bg-gray-200 rounded w-32 animate-pulse" />
+                  </div>
+                </div>
+              </div>
+
+              {/* 상세 정보 섹션 스켈레톤 */}
+              <div className="flex-col gap-10 w-full">
+                <div className="flex-col gap-2">
+                  <div className="h-5 bg-gray-200 rounded w-32 animate-pulse" />
+                  <div className="h-6 bg-gray-200 rounded w-full animate-pulse" />
+                </div>
+                <div className="flex-col gap-2">
+                  <div className="h-5 bg-gray-200 rounded w-24 animate-pulse" />
+                  <div className="h-6 bg-gray-200 rounded w-full animate-pulse" />
+                  <div className="h-6 bg-gray-200 rounded w-3/4 animate-pulse" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/services/portfolio/getAllViewerPortfolioData.server.ts
+++ b/src/services/portfolio/getAllViewerPortfolioData.server.ts
@@ -41,6 +41,8 @@ export interface ViewerPortfolioData {
     description: string | null;
     profile_image: string | null;
     email: string | null;
+    status: string;
+    role: string[];
   };
   student: {
     name: string | null;
@@ -177,12 +179,18 @@ export async function getAllViewerPortfolioData(): Promise<ViewerPortfolioData[]
         }
       });
 
+      const jobNames = (profile.student?.student_jobs || [])
+        .map((sj) => sj.job?.job_name)
+        .filter((name): name is string => name !== null && name !== undefined);
+
       return {
         profile: {
           profile_name: profile.profile_name,
           description: profile.description,
           profile_image: profile.profile_image,
           email: profile.email,
+          status: '구직 중', // 기본값 (getPersonalPortfolioData와 동일)
+          role: jobNames,
         },
         student: profile.student
           ? {

--- a/src/services/portfolio/getAllViewerPortfolioData.server.ts
+++ b/src/services/portfolio/getAllViewerPortfolioData.server.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient } from '@/services/supabase/server';
+import { calculateGradeFromJoinAt } from '@/utils/student/studentCalculations';
 
 // Supabase 쿼리 결과 타입 (간소화)
 type ProfileWithRelations = {
@@ -143,10 +144,16 @@ export async function getAllViewerPortfolioData(): Promise<ViewerPortfolioData[]
     return [];
   }
 
-  // 데이터 변환
+  // 데이터 변환 및 2학년 필터링
   const portfolioData: ViewerPortfolioData[] = (
     profiles as ProfileWithRelations[]
   )
+    .filter((profile) => {
+      // 입학년도(join_at)로 2학년 계산하여 필터링
+      const joinAt = profile.student?.join_at;
+      const grade = calculateGradeFromJoinAt(joinAt || null);
+      return grade === 2;
+    })
     .map((profile) => {
       // 프로젝트 중복 제거 및 병합
       const projectMap = new Map<string, {

--- a/src/utils/portfolioUtils.ts
+++ b/src/utils/portfolioUtils.ts
@@ -1,6 +1,27 @@
 import { converIsTeamToUrl } from '@/utils/convertIsTeamToUrl';
 
 /**
+ * 데이터 배열에서 고유한 학과 목록을 추출하는 유틸리티 함수
+ * DRY 원칙에 따라 SearchTab과 ViewerContent에서 공통으로 사용
+ * @param data - 학과 정보를 포함한 데이터 배열
+ * @param getDepartmentName - 각 아이템에서 학과 이름을 추출하는 함수
+ * @returns 중복 제거 및 정렬된 학과 이름 배열
+ */
+export const extractUniqueDepartments = <T,>(
+  data: T[],
+  getDepartmentName: (item: T) => string | null | undefined,
+): string[] => {
+  const deptSet = new Set<string>();
+  data.forEach((item) => {
+    const deptName = getDepartmentName(item);
+    if (deptName) {
+      deptSet.add(deptName);
+    }
+  });
+  return Array.from(deptSet).sort((a, b) => a.localeCompare(b, 'ko'));
+};
+
+/**
  * null 또는 undefined 값을 fallback 값으로 대체하는 유틸리티 함수
  * @param value - 체크할 값
  * @param fallback - value가 null/undefined일 때 반환할 기본값 (기본값: '')

--- a/src/utils/portfolioUtils.ts
+++ b/src/utils/portfolioUtils.ts
@@ -1,5 +1,129 @@
 import { converIsTeamToUrl } from '@/utils/convertIsTeamToUrl';
 
+// 취업 상태 상수
+export const JOB_SEEKING_STATUS = ['구직 중', '구직중', '취업 희망', '취업희망'];
+export const EMPLOYED_STATUS = ['취업', '재직 중', '재직중'];
+
+/**
+ * 필터 상태 타입 정의
+ */
+export interface FilterState {
+  jobs: string[];
+  departments: string[];
+  showOnlyJobSeeking: boolean;
+  showOnlyEmployed: boolean;
+}
+
+/**
+ * 필터링 가능한 포트폴리오 아이템에 필요한 필드 접근자 인터페이스
+ */
+export interface PortfolioFilterAccessors<T> {
+  getProfileName: (item: T) => string | null | undefined;
+  getStudentName: (item: T) => string | null | undefined;
+  getProjects: (item: T) => Array<{
+    name?: string | null;
+    description?: string | null;
+  }>;
+  getDepartmentName: (item: T) => string | null | undefined;
+  getRoles: (item: T) => string[];
+  getStatus: (item: T) => string;
+}
+
+/**
+ * 포트폴리오 필터링 함수들을 생성하는 팩토리 함수
+ * DRY 원칙에 따라 SearchTab과 ViewerContent에서 공통으로 사용
+ * @param searchTerm - 검색어
+ * @param filter - 필터 상태
+ * @param accessors - 데이터 접근자 객체
+ * @returns 필터링 함수들을 담은 객체
+ */
+export const createPortfolioFilters = <T>(
+  searchTerm: string,
+  filter: FilterState,
+  accessors: PortfolioFilterAccessors<T>,
+) => ({
+  /**
+   * 검색어로 필터링
+   */
+  filterBySearchTerm: (data: T): boolean => {
+    if (!searchTerm) return true;
+    const searchLower = searchTerm.toLowerCase();
+    const profileName = accessors.getProfileName(data);
+    const studentName = accessors.getStudentName(data);
+    const projects = accessors.getProjects(data);
+
+    return (
+      profileName?.toLowerCase().includes(searchLower) ||
+      studentName?.toLowerCase().includes(searchLower) ||
+      projects.some(
+        (project) =>
+          project.name?.toLowerCase().includes(searchLower) ||
+          project.description?.toLowerCase().includes(searchLower),
+      )
+    );
+  },
+
+  /**
+   * 학과로 필터링
+   */
+  filterByDepartments: (data: T): boolean => {
+    if (filter.departments.length === 0) return true;
+    const deptName = accessors.getDepartmentName(data);
+    return deptName ? filter.departments.includes(deptName) : false;
+  },
+
+  /**
+   * 직무로 필터링
+   */
+  filterByJobs: (data: T): boolean => {
+    if (filter.jobs.length === 0) return true;
+    return accessors.getRoles(data).some((role) => filter.jobs.includes(role));
+  },
+
+  /**
+   * 취업 상태로 필터링
+   */
+  filterByEmploymentStatus: (data: T): boolean => {
+    const { showOnlyJobSeeking, showOnlyEmployed } = filter;
+    // 둘 다 선택되거나 둘 다 선택되지 않은 경우
+    if (showOnlyJobSeeking === showOnlyEmployed) return true;
+
+    const status = accessors.getStatus(data);
+
+    if (showOnlyJobSeeking) {
+      return JOB_SEEKING_STATUS.includes(status);
+    }
+
+    if (showOnlyEmployed) {
+      return EMPLOYED_STATUS.includes(status);
+    }
+
+    return true;
+  },
+});
+
+/**
+ * 포트폴리오 데이터를 모든 필터 조건으로 필터링
+ * @param data - 필터링할 포트폴리오 데이터 배열
+ * @param searchTerm - 검색어
+ * @param filter - 필터 상태
+ * @param accessors - 데이터 접근자 객체
+ * @returns 필터링된 데이터 배열
+ */
+export const filterPortfolioData = <T>(
+  data: T[],
+  searchTerm: string,
+  filter: FilterState,
+  accessors: PortfolioFilterAccessors<T>,
+): T[] => {
+  const filters = createPortfolioFilters(searchTerm, filter, accessors);
+  return data
+    .filter(filters.filterBySearchTerm)
+    .filter(filters.filterByDepartments)
+    .filter(filters.filterByJobs)
+    .filter(filters.filterByEmploymentStatus);
+};
+
 /**
  * 데이터 배열에서 고유한 학과 목록을 추출하는 유틸리티 함수
  * DRY 원칙에 따라 SearchTab과 ViewerContent에서 공통으로 사용

--- a/src/utils/student/studentCalculations.ts
+++ b/src/utils/student/studentCalculations.ts
@@ -68,6 +68,30 @@ export function calculateGradeFromStudentNumber(
 }
 
 /**
+ * 생년월일로 현재 학년 계산
+ * 마이스터고는 15세에 입학하므로, 입학년도 = 생년 + 15
+ * 현재 학년 = 현재 연도 - 입학년도 + 1
+ * @param birthday - 생년월일 날짜 문자열
+ * @returns 학년 (1, 2, 3), 계산 불가능한 경우 0
+ */
+export function calculateGradeFromBirthday(birthday: string | null): number {
+  if (!birthday) return 0;
+
+  const birthYear = extractYearFromDate(birthday);
+  if (birthYear === -1) return 0;
+
+  const currentYear = getCurrentYear();
+  const enrollmentYear = birthYear + 15; // 마이스터고는 15세에 입학
+  const grade = currentYear - enrollmentYear + 1;
+
+  // 학년은 1~3학년 범위로 제한 (마이스터고는 3년제)
+  if (grade < 1) return 0;
+  if (grade > 3) return 0; // 졸업생도 0으로 처리
+
+  return grade;
+}
+
+/**
  * 기수 계산
  * 현재 연도 기준: 현재 연도 - 창립년도 + 1 = 기수
  * @param foundedYear - 창립년도


### PR DESCRIPTION
# [I25-394] viewer 페이지에 필터 기능 추가

## 💡 개요

viewer 페이지(`/viewer`)에 포트폴리오 필터 기능을 추가하여 사용자가 학과, 직무분야, 구직/취직 상태로 포트폴리오를 필터링할 수 있도록 구현했습니다. `/viewer?filter=true` 쿼리 파라미터가 있을 때 필터 사이드바가 왼쪽에 표시되며, 필터링된 결과가 실시간으로 반영됩니다.

또한 필터 사이드바를 재사용 가능한 컴포넌트로 분리하여 portfolio 페이지와 공유하고, 풀 라우트 캐시를 최적화하여 필터가 없을 때는 정적 렌더링을 유지하도록 개선했습니다.

## 📃 작업내용

### 1. 필터 사이드바 컴포넌트 분리

SearchTab 컴포넌트의 필터 UI를 재사용 가능한 FilterSidebar 컴포넌트로 분리했습니다.

```mermaid
graph TD
    A["SearchTab 컴포넌트"] --> B["FilterSidebar 분리"]
    B --> C["FilterSidebar 컴포넌트 생성"]
    C --> D["SearchTab에서 FilterSidebar 사용"]
    C --> E["ViewerContent에서 FilterSidebar 사용"]
    D --> F["portfolio 페이지"]
    E --> G["viewer 페이지"]
```

### 2. ViewerPortfolioData 타입 확장

필터링을 위해 ViewerPortfolioData 타입에 status와 role 필드를 추가했습니다.

```mermaid
graph TD
    A[getAllViewerPortfolioData] --> B["프로필 데이터 조회"]
    B --> C["student_jobs에서 job_name 추출"]
    C --> D["role 배열 생성"]
    D --> E["status 기본값 '구직 중' 설정"]
    E --> F["ViewerPortfolioData 반환"]
```

### 3. viewer 페이지 필터 기능 구현

viewer 페이지에 필터 기능을 추가하고 (box-layout)으로 이동했습니다.

```mermaid
graph TD;
    A[/viewer 접속/] --> B{filter 파라미터 확인};
    B -->|없음| C[ViewerStatic 서버 컴포넌트];
    B -->|있음| D[ViewerContent 클라이언트 컴포넌트];
    C --> E[정적 렌더링 - 풀 라우트 캐시];
    D --> F[동적 렌더링];
    F --> G[FilterSidebar 표시];
    G --> H[필터 상태 관리];
    H --> I[필터링 로직 적용];
    I --> J[필터링된 결과 표시];

```

### 4. 필터링 로직

검색어, 학과, 직무분야, 구직/취직 상태에 따라 포트폴리오를 필터링합니다.

```mermaid
graph TD
    A[포트폴리오 데이터] --> B[검색어 필터링]
    B --> C[학과 필터링]
    C --> D[직무분야 필터링]
    D --> E[구직/취직 상태 필터링]
    E --> F[필터링된 결과]
    F --> G[배너 및 포트폴리오 아이템 생성]
    G --> H[화면에 렌더링]
```

### 5. 주요 구현 내용

1. **FilterSidebar 컴포넌트 생성** (`src/app/components/portfolio/FilterSidebar.tsx`)
   - 검색 입력, 학과 필터, 직무분야 필터, 옵션 필터(구직 중/취직 중) 포함
   - FilterState 인터페이스로 필터 상태 관리
   - props로 필터 상태와 핸들러를 받아 재사용 가능하게 구성

2. **ViewerPortfolioData 타입 확장** (`getAllViewerPortfolioData.server.ts`)
   - `profile.status`: 구직/취직 상태 필터링을 위한 필드 추가
   - `profile.role`: 직무분야 필터링을 위한 필드 추가 (jobs 배열에서 추출)

3. **viewer 페이지 구조 개선**
   - `ViewerStatic`: 필터가 없을 때 사용하는 서버 컴포넌트 (정적 렌더링)
   - `ViewerContent`: 필터가 있을 때 사용하는 클라이언트 컴포넌트 (동적 렌더링)
   - `(viewer)` 레이아웃에서 `(box-layout)`으로 이동하여 일관된 레이아웃 유지

4. **필터링 로직 구현**
   - 검색어: 프로필 이름, 학생 이름, 프로젝트 이름/설명에서 검색
   - 학과: department_name으로 필터링
   - 직무분야: profile.role 배열과 매칭
   - 구직/취직 상태: profile.status로 필터링

5. **스켈레톤 컴포넌트 추가** (`src/app/components/viewer/ViewerSkeleton.tsx`)
   - Suspense fallback으로 사용되는 로딩 스켈레톤
   - 필터 사이드바와 포트폴리오 카드 형태의 스켈레톤 UI

## 🔀 변경사항

### 추가 개선사항

1. **풀 라우트 캐시 최적화**
   - 필터가 없을 때(`/viewer`): ViewerStatic 서버 컴포넌트로 정적 렌더링
   - 필터가 있을 때(`/viewer?filter=true`): ViewerContent 클라이언트 컴포넌트로 동적 렌더링
   - `revalidate = 3600`으로 1시간마다 재검증되는 정적 페이지 유지

2. **레이아웃 일관성 개선**
   - viewer 페이지를 `(box-layout)`으로 이동하여 portfolio 페이지와 동일한 레이아웃 사용
   - 필터 on/off와 관계없이 일관된 레이아웃 구조 유지

3. **컴포넌트 재사용성 향상**
   - FilterSidebar를 독립 컴포넌트로 분리하여 portfolio와 viewer에서 공유
   - SearchTab도 FilterSidebar를 사용하도록 리팩토링

4. **학과 필터 추가**
   - 초기 요구사항에 없었으나 필터 기능 확장으로 학과 필터 추가
   - portfolio 페이지에도 동일하게 적용

## 주요 파일 변경

- `src/app/components/portfolio/FilterSidebar.tsx` (신규)
- `src/app/components/portfolio/SearchTab.tsx`
- `src/services/portfolio/getAllViewerPortfolioData.server.ts`
- `src/app/(box-layout)/viewer/page.tsx` (신규)
- `src/app/(box-layout)/viewer/ViewerContent.tsx` (신규)
- `src/app/(box-layout)/viewer/ViewerStatic.tsx` (신규)
- `src/app/components/viewer/ViewerSkeleton.tsx` (신규)
- `src/app/(viewer)/viewer/page.tsx` (삭제)

## 📸 스크린샷
<img width="664" height="1941" alt="image" src="https://github.com/user-attachments/assets/5dafdb7a-da94-4b75-a697-9be232bad975" />


[I25-394]: https://obtuse-t.atlassian.net/browse/I25-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ