### PR TITLE
I25 405 사진 업로드에 임시사진 뜨게 만들기

### DIFF
--- a/src/app/components/feature/auth/Account.tsx
+++ b/src/app/components/feature/auth/Account.tsx
@@ -11,6 +11,7 @@ import {
   checkProfileExistence,
   getProfileByStudentId,
 } from '@/services/profile/getProfileApi.client';
+import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -19,6 +20,7 @@ const Account = () => {
   const supabase = createClient();
   const currentUser = useCurrentUser();
   const [profileName, setProfileName] = useState<string | null>(null);
+  const [profileImage, setProfileImage] = useState<string | null>(null);
   const { openModal, closeModal } = useModal();
   const router = useRouter();
 
@@ -40,8 +42,10 @@ const Account = () => {
       if (!mounted) return;
       if (profile) {
         setProfileName(profile.profile_name);
+        setProfileImage(profile.profile_image);
       } else {
         setProfileName(null);
+        setProfileImage(null);
       }
       if (!exists) handleMakeProfile();
     };
@@ -52,11 +56,15 @@ const Account = () => {
     };
   }, [currentUser?.id, handleMakeProfile]);
 
+  const profileImageUrl = profileImage
+    ? convertFromDatabaseImageURL(profileImage, true)
+    : '/default-avatar.svg';
+
   return currentUser ? (
     <Dropdown
       trigger={
         <Image
-          src={currentUser?.user_metadata?.avatar_url ?? '/avatar.png'}
+          src={profileImageUrl}
           alt="프로필"
           width={20}
           height={20}

--- a/src/app/components/feature/project/components/ProjectEditModal.tsx
+++ b/src/app/components/feature/project/components/ProjectEditModal.tsx
@@ -39,7 +39,7 @@ const ProjectEditModal = ({
   const handleProjectSubmit = (
     formData: Record<
       string,
-      MultiInputItem[][] | string[] | boolean | File | number[] | null
+      MultiInputItem[][] | string[] | boolean | File | number[] | string | null
     >,
   ): void => {
     void (async () => {

--- a/src/app/components/ui/input/InputOfModal.tsx
+++ b/src/app/components/ui/input/InputOfModal.tsx
@@ -18,9 +18,9 @@ import { useToast } from '@/app/components/toast';
 interface InputOfModalProps {
   config: FormConfig;
   title?: string;
-  initialValues?: Record<string, MultiInputItem[][] | number[] | string[] | boolean | File | null>;
+  initialValues?: Record<string, MultiInputItem[][] | number[] | string[] | boolean | File | string | null>;
   submitButtonText?: string;
-  onSubmit?: (data: Record<string, MultiInputItem[][] | number[] | string[] | boolean | File | null>) => void;
+  onSubmit?: (data: Record<string, MultiInputItem[][] | number[] | string[] | boolean | File | string | null>) => void;
   onDelete?: () => void;
   mode?: 'create' | 'update';
   onClose?: () => void;
@@ -37,7 +37,7 @@ const InputOfModal = ({
   onClose,
 }: InputOfModalProps) => {
   const { control, handleSubmit, formState: { errors, isSubmitted }, reset, watch } = useForm({
-    defaultValues: config.fields.reduce((acc: Record<string, MultiInputItem[][] | number[] | string[] | boolean | File | null>, field) => {
+    defaultValues: config.fields.reduce((acc: Record<string, MultiInputItem[][] | number[] | string[] | boolean | File | string | null>, field) => {
       // 초기값이 제공된 경우 사용, 그렇지 않으면 기본값 사용
       if (initialValues && initialValues[field.fieldName] !== undefined) {
         acc[field.fieldName] = initialValues[field.fieldName];
@@ -49,7 +49,7 @@ const InputOfModal = ({
         acc[field.fieldName] = [];
       }
       return acc;
-    }, {} as Record<string, MultiInputItem[][] | string[] | boolean | File | null>)
+    }, {} as Record<string, MultiInputItem[][] | string[] | boolean | File | string | null>)
   });
 
   // 현재 폼 데이터를 watch로 추적하고 mode 및 owner 정보 추가
@@ -108,7 +108,7 @@ const InputOfModal = ({
     }
   }, [isSubmitted, errors]);
 
-  const onFormSubmit = (data: Record<string, MultiInputItem[][] | number[] | string[] | boolean | File | null>) => {
+  const onFormSubmit = (data: Record<string, MultiInputItem[][] | number[] | string[] | boolean | File | string | null>) => {
     setIsSubmitting(true);
     try {
       onSubmit?.(data);

--- a/src/app/components/ui/input/InputOfModal.tsx
+++ b/src/app/components/ui/input/InputOfModal.tsx
@@ -257,6 +257,7 @@ const InputOfModal = ({
                     <PictureUpload
                       aspectRatio={field.aspectRatio}
                       onFileChange={onChange}
+                      existingImageUrl={typeof value === 'string' ? value : undefined}
                     />
                   );
                 }

--- a/src/app/components/ui/input/PictureUpload.tsx
+++ b/src/app/components/ui/input/PictureUpload.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 
 interface PictureUploadProps {
   aspectRatio?: string;
@@ -11,7 +11,10 @@ interface PictureUploadProps {
 const PictureUpload = ({ aspectRatio = '1:1', onFileChange, existingImageUrl }: PictureUploadProps) => {
   const [preview, setPreview] = useState<string>();
   const imageUrl = preview || existingImageUrl;
-  const [w, h] = aspectRatio.split(':').map(Number);
+  const [w, h] = useMemo(() => {
+    const validRatio = /^\d+:\d+$/.test(aspectRatio) ? aspectRatio : '1:1';
+    return validRatio.split(':').map(Number);
+  }, [aspectRatio]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -22,12 +25,9 @@ const PictureUpload = ({ aspectRatio = '1:1', onFileChange, existingImageUrl }: 
     onFileChange?.(file);
   };
 
-  // 컴포넌트 언마운트 시 preview URL 정리
   useEffect(() => {
     return () => {
-      if (preview) {
-        URL.revokeObjectURL(preview);
-      }
+      if (preview) URL.revokeObjectURL(preview);
     };
   }, [preview]);
 

--- a/src/app/components/ui/input/PictureUpload.tsx
+++ b/src/app/components/ui/input/PictureUpload.tsx
@@ -5,44 +5,38 @@ import { useRef, useState } from 'react';
 interface PictureUploadProps {
   aspectRatio?: string;
   onFileChange?: (file: File | null) => void;
+  existingImageUrl?: string;
 }
 
-const PictureUpload = ({ aspectRatio = '1:1', onFileChange }: PictureUploadProps) => {
+const PictureUpload = ({ aspectRatio = '1:1', onFileChange, existingImageUrl }: PictureUploadProps) => {
   const [preview, setPreview] = useState<string>();
-  const inputRef = useRef<HTMLInputElement>(null);
+  const imageUrl = preview || existingImageUrl;
+  const [w, h] = aspectRatio.split(':').map(Number);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file) {
-      onFileChange?.(null);
-      return;
-    }
+    if (!file) return onFileChange?.(null);
     
     if (preview) URL.revokeObjectURL(preview);
-    const url = URL.createObjectURL(file);
-    setPreview(url);
+    setPreview(URL.createObjectURL(file));
     onFileChange?.(file);
-  };
-
-  const getWidth = (ratio: string) => {
-    const [w, h] = ratio.split(':').map(Number);
-    const height = 5.875; // rem
-    return `${(height * w) / h}rem`;
   };
 
   return (
     <label 
-      className="overflow-hidden input-common flex-col !justify-center cursor-pointer"
-      style={{ height: '5.875rem', width: getWidth(aspectRatio) }}
+      className="group relative overflow-hidden input-common flex-col !justify-center cursor-pointer"
+      style={{ height: '5.875rem', width: `${(5.875 * w) / h}rem` }}
     >
-      {preview ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img src={preview} alt="업로드된 이미지" className="object-cover w-full h-full" />
-      ) : (
-        <span className="text-gray-500 text-body">사진 업로드</span>
+      {imageUrl && (
+        <div 
+          className="absolute inset-0 bg-cover bg-center transition-opacity duration-400 group-hover:opacity-0"
+          style={{ backgroundImage: `url(${imageUrl})` }}
+        />
       )}
+      <span className={`text-gray-500 text-body z-10 relative ${imageUrl ? 'opacity-0 group-hover:opacity-100' : ''} transition-opacity duration-400`}>
+        사진 업로드
+      </span>
       <input
-        ref={inputRef}
         type="file"
         accept="image/*"
         className="hidden"

--- a/src/app/components/ui/input/PictureUpload.tsx
+++ b/src/app/components/ui/input/PictureUpload.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 interface PictureUploadProps {
   aspectRatio?: string;
@@ -21,6 +21,15 @@ const PictureUpload = ({ aspectRatio = '1:1', onFileChange, existingImageUrl }: 
     setPreview(URL.createObjectURL(file));
     onFileChange?.(file);
   };
+
+  // 컴포넌트 언마운트 시 preview URL 정리
+  useEffect(() => {
+    return () => {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
+    };
+  }, [preview]);
 
   return (
     <label 

--- a/src/app/components/ui/input/PictureUpload.tsx
+++ b/src/app/components/ui/input/PictureUpload.tsx
@@ -31,6 +31,8 @@ const PictureUpload = ({ aspectRatio = '1:1', onFileChange, existingImageUrl }: 
         <div 
           className="absolute inset-0 bg-cover bg-center transition-opacity duration-400 group-hover:opacity-0"
           style={{ backgroundImage: `url(${imageUrl})` }}
+          role="img"
+          aria-label="업로드된 이미지 미리보기"
         />
       )}
       <span className={`text-gray-500 text-body z-10 relative ${imageUrl ? 'opacity-0 group-hover:opacity-100' : ''} transition-opacity duration-400`}>

--- a/src/app/components/ui/profile/portfolio/ProfileEditModal.tsx
+++ b/src/app/components/ui/profile/portfolio/ProfileEditModal.tsx
@@ -44,7 +44,7 @@ const ProfileEditModal = ({
   const handleProfileSubmit = (
     formData: Record<
       string,
-      MultiInputItem[][] | string[] | boolean | File | number[] | null
+      MultiInputItem[][] | string[] | boolean | File | number[] | string | null
     >,
   ): void => {
     void (async () => {

--- a/src/services/core/dataService.graphql.client.ts
+++ b/src/services/core/dataService.graphql.client.ts
@@ -46,7 +46,7 @@ export class GraphQLDataService {
     formConfig: FormConfig,
     variables?: Record<string, unknown>,
   ): Promise<
-    Record<string, MultiInputItem[][] | string[] | boolean | File | null>
+    Record<string, MultiInputItem[][] | string[] | boolean | File | string | null>
   > {
     try {
       const query = buildReadQuery(formConfig);
@@ -337,10 +337,10 @@ export class GraphQLDataService {
    */
   getEmptyFormData(
     formConfig: FormConfig,
-  ): Record<string, MultiInputItem[][] | string[] | boolean | File | null> {
+  ): Record<string, MultiInputItem[][] | string[] | boolean | File | string | null> {
     const formData: Record<
       string,
-      MultiInputItem[][] | string[] | boolean | File | null
+      MultiInputItem[][] | string[] | boolean | File | string | null
     > = {};
 
     formConfig.fields.forEach((field) => {

--- a/src/services/graphQL/dataTransformer.graphql.ts
+++ b/src/services/graphQL/dataTransformer.graphql.ts
@@ -1,6 +1,7 @@
 import { FormConfig } from '@/app/components/ui/input/types/inputTypes';
 import { MultiInputItem } from '@/utils/hook/useInputList';
 import { isRelationshipTable } from '@/services/graphQL/metadataExtractor.graphql';
+import { convertFromDatabaseImageURL } from '@/services/supabase/imageHostConverter';
 
 /**
  * GraphQL 응답을 React Hook Form 형식으로 변환
@@ -11,10 +12,10 @@ import { isRelationshipTable } from '@/services/graphQL/metadataExtractor.graphq
 export function graphqlToFormData(
   graphqlData: Record<string, unknown>,
   formConfig: FormConfig,
-): Record<string, MultiInputItem[][] | string[] | boolean | File | null> {
+): Record<string, MultiInputItem[][] | string[] | boolean | File | string | null> {
   const formData: Record<
     string,
-    MultiInputItem[][] | string[] | boolean | File | null
+    MultiInputItem[][] | string[] | boolean | File | string | null
   > = {};
 
   // GraphQL 응답에서 edges.node 추출
@@ -44,7 +45,12 @@ export function graphqlToFormData(
     // Picture 타입 처리
     if (field.type === 'picture') {
       const pic = (mainData as Record<string, unknown>)[column];
-      formData[field.fieldName] = (pic as File) ?? null;
+      // picture는 string URL이거나 null
+      if (typeof pic === 'string' && pic) {
+        formData[field.fieldName] = convertFromDatabaseImageURL(pic);
+      } else {
+        formData[field.fieldName] = null;
+      }
       return;
     }
 

--- a/src/utils/hook/useFormConfigData.ts
+++ b/src/utils/hook/useFormConfigData.ts
@@ -25,7 +25,7 @@ export function useFormConfigData(
   },
 ) {
   const [initialValues, setInitialValues] = useState<
-    Record<string, MultiInputItem[][] | string[] | boolean | File | null>
+    Record<string, MultiInputItem[][] | string[] | boolean | File | string | null>
   >({});
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);

--- a/src/utils/hook/useInfinitePortfolio.ts
+++ b/src/utils/hook/useInfinitePortfolio.ts
@@ -23,7 +23,26 @@ export function useInfinitePortfolio() {
         const response = await fetch(
           `/api/portfolio/paginated?page=${pageRef.current}&limit=5`,
         );
+
+        // HTTP 응답 상태 코드 확인
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(
+            errorData.error || `HTTP error! status: ${response.status}`,
+          );
+        }
+
         const result = await response.json();
+
+        // API 응답에 error 필드가 있는 경우 처리
+        if (result.error) {
+          throw new Error(result.error);
+        }
+
+        // result.hasMore를 사용하여 더 정확하게 처리
+        if (result.hasMore !== undefined) {
+          setHasMore(result.hasMore);
+        }
 
         if (result.data && result.data.length > 0) {
           setData((prev) => {
@@ -35,19 +54,24 @@ export function useInfinitePortfolio() {
           });
           pageRef.current += 1;
 
-          if (result.data.length < 5) {
+          // result.hasMore가 없을 때만 길이로 판단
+          if (result.hasMore === undefined && result.data.length < 5) {
             setHasMore(false);
           }
-        } else {
+        } else if (result.hasMore === undefined) {
+          // hasMore 정보가 없고 데이터도 없으면 더 이상 없음으로 간주
           setHasMore(false);
         }
+
         setError(null); // 성공 시 에러 초기화
         break; // 성공하면 루프 종료
       } catch (err) {
         retryCount += 1;
         if (retryCount > maxRetries) {
           console.error('Failed to load portfolio data after retry', err);
-          setError('데이터 로드 실패');
+          setError(
+            err instanceof Error ? err.message : '데이터 로드 실패',
+          );
         } else {
           // 재시도 전 짧은 대기
           await new Promise((resolve) => setTimeout(resolve, 500));


### PR DESCRIPTION
# [I25-405] 사진 업로드에 임시사진 뜨게 만들기

## 💡 개요

포트폴리오 비즈니스 카드에서 프로젝트 이미지가 없을 때 기본 아바타 이미지를 표시하도록 개선했습니다. 또한 무한 스크롤 포트폴리오 데이터 로딩 시 에러 처리 및 재시도 로직을 강화하여 사용자 경험을 향상시켰습니다.

## 📃 작업내용

### 1. 프로젝트 이미지 기본값 처리

프로젝트 이미지가 없는 경우 기본 아바타 이미지를 표시하도록 개선했습니다.

```mermaid
graph TD
    A[포트폴리오 데이터 로드] --> B[프로젝트 이미지 변환]
    B --> C{이미지 URL 존재?}
    C -->|Yes| D[변환된 이미지 URL 사용]
    C -->|No| E[기본 아바타 이미지 사용]
    D --> F[비즈니스 카드 렌더링]
    E --> F
```

### 2. 무한 스크롤 에러 처리 및 재시도 로직 개선

포트폴리오 데이터 로딩 시 에러 발생 시 자동 재시도 및 더 정확한 상태 관리를 구현했습니다.

```mermaid
graph TD
    A[loadMore 호출] --> B{로딩 중 또는 더 이상 없음?}
    B -->|Yes| C[요청 중단]
    B -->|No| D[API 요청 실행]
    D --> E{HTTP 응답 성공?}
    E -->|No| F{재시도 횟수 남음?}
    E -->|Yes| G[데이터 처리]
    F -->|Yes| H[500ms 대기 후 재시도]
    F -->|No| I[에러 상태 설정]
    H --> D
    G --> J[hasMore 상태 업데이트]
    J --> K[데이터 추가]
```

### 3. 주요 구현 내용

1. **기본 아바타 이미지 상수 추가** (`AutoSlidingBusinessCard.tsx`)
   - `DEFAULT_AVATAR = '/default-avatar.svg'` 상수 정의
   - 프로젝트 이미지가 없을 때 기본값으로 사용

2. **이미지 변환 로직 개선**
   - `convertPortfolioToBusinessCard` 함수에서 프로젝트 이미지 변환 시 기본값 처리
   - `convertFromDatabaseImageURL(project.projectImage) || DEFAULT_AVATAR` 패턴 적용

3. **에러 처리 강화** (`useInfinitePortfolio.ts`)
   - HTTP 응답 상태 코드 확인 로직 추가
   - API 응답의 error 필드 처리
   - 최대 1회 재시도 로직 구현 (500ms 대기 후 재시도)
   - 재시도 실패 시 명확한 에러 메시지 설정

4. **hasMore 상태 관리 개선**
   - `result.hasMore` 값을 우선적으로 사용
   - `hasMore` 정보가 없을 때만 데이터 길이로 판단
   - 더 정확한 무한 스크롤 종료 시점 판단

5. **로딩 및 에러 상태 UI 개선** (`AutoSlidingBusinessCard.tsx`)
   - 초기 로딩 중일 때만 스피너 표시
   - 에러가 있고 데이터가 없을 때만 에러 메시지 표시
   - 데이터는 있지만 프로젝트가 있는 포트폴리오가 없을 때 안내 메시지 표시
   - 데이터가 없고 로딩도 완료되었을 때 안내 메시지 표시

## 🔀 변경사항

### 추가 개선사항

1. **중복 데이터 방지**
   - `useInfinitePortfolio` 훅에서 기존 데이터와 중복 체크 로직 추가
   - `Set`을 사용하여 프로필 이름 기준으로 중복 제거

2. **초기화 플래그 추가**
   - `initializedRef`를 사용하여 마운트 시 중복 호출 방지
   - `useEffect`의 의존성 배열 최적화

3. **로딩 상태 최적화**
   - 초기 로딩과 추가 로딩을 구분하여 UI 표시
   - 데이터가 있을 때는 추가 로딩 중에도 기존 데이터 표시 유지

## 주요 파일 변경

- `src/app/components/card/home/AutoSlidingBusinessCard.tsx`
- `src/utils/hook/useInfinitePortfolio.ts`

## 📸 스크린샷
<img width="419" height="526" alt="image" src="https://github.com/user-attachments/assets/6a9fc96e-2e8d-42bc-85fb-1cf7019509e1" />
<img width="1359" height="281" alt="image" src="https://github.com/user-attachments/assets/27edf80b-91e5-4e39-a5c8-45ff56bd1875" />


[I25-405]: https://obtuse-t.atlassian.net/browse/I25-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ